### PR TITLE
chore: add branch push CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches-ignore:
+      - main
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Lint, Test, Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pre-PR checks
+        run: ./scripts/pre-pr.sh
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

Add GitHub Actions CI for non-main branch pushes.

## Task

- todu task: #2221

## Changes

- add `.github/workflows/ci.yml`
- trigger CI on `push` to all branches except `main`
- run `npm ci`
- run `./scripts/pre-pr.sh`
- run `npm run build`

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included
