### PR TITLE
feat: implement phase 4 comment sync

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "todu-github-plugin",
       "version": "0.1.0",
       "dependencies": {
-        "@todu/core": "^0.5.0"
+        "@todu/core": "^0.7.0"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1089,9 +1089,9 @@
       "license": "MIT"
     },
     "node_modules/@todu/core": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.5.0.tgz",
-      "integrity": "sha512-ltNzjJQnlMgo1yjfGX79DNyZbU9bR7Ggmc+1LGWSxEdLg80zMTMGOs1P1lz17gT7p96E6ar4mZVbeDu9YE+BZw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.7.0.tgz",
+      "integrity": "sha512-QoMWyGMrQ8roI+Cdz/7SoJsG/iUg0scERwEFnflJOZk0hVbJ9bHurZuBZeQRHnAHjemWEsOEex16yftmxRvjMw==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@todu/core": "^0.5.0"
+    "@todu/core": "^0.7.0"
   }
 }

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -21,6 +21,6 @@ describe("syncProvider registration", () => {
     }
 
     expect(result.value.manifest.name).toBe("github");
-    expect(result.value.manifest.apiVersion).toBe(1);
+    expect(result.value.manifest.apiVersion).toBe(2);
   });
 });

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -4,11 +4,13 @@ import path from "node:path";
 
 import {
   createIntegrationBindingId,
+  createNoteId,
   createProjectId,
   createTaskId,
   type IntegrationBinding,
+  type Note,
   type Project,
-  type TaskWithDetail,
+  type TaskPushPayload,
 } from "@todu/core";
 import { describe, expect, it } from "vitest";
 
@@ -20,9 +22,13 @@ import {
   GitHubProviderConfigError,
   createGitHubIssueUpdateFromTask,
   createGitHubSyncProvider,
+  createInMemoryGitHubCommentLinkStore,
   createInMemoryGitHubIssueClient,
   createInMemoryGitHubItemLinkStore,
   createLinkFromTask,
+  formatAttributedBody,
+  formatGitHubAttribution,
+  formatToduAttribution,
   getNormalGitHubLabels,
   loadGitHubProviderSettings,
   normalizeGitHubIssuePriority,
@@ -30,6 +36,8 @@ import {
   parseGitHubBinding,
   parseGitHubRepositoryTargetRef,
   parseIssueExternalId,
+  stripAttribution,
+  type GitHubComment,
 } from "@/index";
 
 describe("parseGitHubRepositoryTargetRef", () => {
@@ -479,6 +487,7 @@ describe("createGitHubSyncProvider", () => {
           title: "Persisted issue",
         }),
       ],
+      comments: [],
     });
     expect(secondProvider.getState().itemLinks).toEqual([
       {
@@ -525,7 +534,7 @@ describe("createGitHubSyncProvider", () => {
         ],
         createProject()
       )
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual({ commentLinks: [] });
     await expect(
       provider.pull(createBinding({ strategy: "none" }), createProject())
     ).resolves.toEqual({
@@ -539,6 +548,466 @@ describe("createGitHubSyncProvider", () => {
       createdLinks: [],
       taskUpdates: [],
     });
+  });
+});
+
+describe("comment attribution formatting", () => {
+  it("formats GitHub attribution with author and timestamp", () => {
+    expect(formatGitHubAttribution("octocat", "2026-03-08T22:00:00Z")).toBe(
+      "_Synced from GitHub comment by @octocat on 2026-03-08T22:00:00Z_"
+    );
+  });
+
+  it("formats todu attribution with author and timestamp", () => {
+    expect(formatToduAttribution("alice", "2026-03-08T22:00:00Z")).toBe(
+      "_Synced from todu comment by @alice on 2026-03-08T22:00:00Z_"
+    );
+  });
+
+  it("builds attributed body with header and original content", () => {
+    const attribution = formatGitHubAttribution("octocat", "2026-03-08T22:00:00Z");
+    expect(formatAttributedBody(attribution, "Hello world")).toBe(
+      "_Synced from GitHub comment by @octocat on 2026-03-08T22:00:00Z_\n\nHello world"
+    );
+  });
+
+  it("strips GitHub attribution from body", () => {
+    const body =
+      "_Synced from GitHub comment by @octocat on 2026-03-08T22:00:00Z_\n\nOriginal body";
+    expect(stripAttribution(body)).toBe("Original body");
+  });
+
+  it("strips todu attribution from body", () => {
+    const body = "_Synced from todu comment by @alice on 2026-03-08T22:00:00Z_\n\nOriginal body";
+    expect(stripAttribution(body)).toBe("Original body");
+  });
+
+  it("returns body unchanged when no attribution is present", () => {
+    expect(stripAttribution("Just a normal comment")).toBe("Just a normal comment");
+  });
+});
+
+describe("comment sync", () => {
+  it("pulls GitHub comments as ExternalComment with attribution", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with comments",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Hello from GitHub",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    const pullResult = await provider.pull(createBinding(), createProject());
+
+    expect(pullResult.comments).toHaveLength(1);
+    expect(pullResult.comments![0]).toMatchObject({
+      externalId: "100",
+      externalTaskId: "evcraddock/todu-github-plugin#1",
+      body: expect.stringContaining("_Synced from GitHub comment by @octocat on"),
+      author: "octocat",
+    });
+    expect(pullResult.comments![0].body).toContain("Hello from GitHub");
+  });
+
+  it("pushes todu comments to GitHub with todu attribution", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue for comment push",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    const provider = createGitHubSyncProvider({ issueClient, linkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const result = await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue for comment push",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Hello from todu",
+              author: "alice",
+              createdAt: "2026-03-10T01:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(result.commentLinks).toHaveLength(1);
+    expect(result.commentLinks[0]).toMatchObject({
+      localNoteId: createNoteId("note-1"),
+      externalTaskId: "evcraddock/todu-github-plugin#1",
+    });
+
+    const ghComments = issueClient.snapshotComments(repositoryTarget(), 1);
+    expect(ghComments).toHaveLength(1);
+    expect(ghComments[0].body).toContain("_Synced from todu comment by @alice on");
+    expect(ghComments[0].body).toContain("Hello from todu");
+  });
+
+  it("updates mirrored GitHub comment when todu note is edited", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with editable comment",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    const provider = createGitHubSyncProvider({ issueClient, linkStore, commentLinkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with editable comment",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Original content",
+              author: "alice",
+              createdAt: "2026-03-10T01:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)[0].body).toContain(
+      "Original content"
+    );
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with editable comment",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Updated content",
+              author: "alice",
+              createdAt: "2026-03-10T02:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    const ghComments = issueClient.snapshotComments(repositoryTarget(), 1);
+    expect(ghComments).toHaveLength(1);
+    expect(ghComments[0].body).toContain("Updated content");
+    expect(ghComments[0].body).not.toContain("Original content");
+  });
+
+  it("deletes mirrored GitHub comment when todu note is removed", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with deletable comment",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    const provider = createGitHubSyncProvider({ issueClient, linkStore, commentLinkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with deletable comment",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "To be deleted",
+              author: "alice",
+              createdAt: "2026-03-10T01:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with deletable comment",
+          status: "active",
+          comments: [],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(0);
+    expect(provider.getState().commentLinks).toHaveLength(0);
+  });
+
+  it("detects deleted GitHub comments during pull and removes comment links", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with comment to delete on GitHub",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 200,
+        issueNumber: 1,
+        body: "Will be deleted",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const provider = createGitHubSyncProvider({ issueClient, linkStore, commentLinkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.comments).toHaveLength(1);
+    expect(provider.getState().commentLinks).toHaveLength(1);
+
+    await issueClient.deleteComment(repositoryTarget(), 200);
+
+    const secondPull = await provider.pull(createBinding(), createProject());
+    expect(secondPull.comments).toHaveLength(0);
+    expect(provider.getState().commentLinks).toHaveLength(0);
+  });
+
+  it("resolves comment edit conflicts with last-write-wins using timestamps", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with conflict",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    const provider = createGitHubSyncProvider({ issueClient, linkStore, commentLinkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with conflict",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "First version",
+              author: "alice",
+              createdAt: "2026-03-10T01:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    const initialComment = issueClient.snapshotComments(repositoryTarget(), 1)[0];
+    expect(initialComment.body).toContain("First version");
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with conflict",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Older edit should not overwrite",
+              author: "alice",
+              createdAt: "2026-03-10T00:30:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    const afterOlderEdit = issueClient.snapshotComments(repositoryTarget(), 1)[0];
+    expect(afterOlderEdit.body).toContain("First version");
+    expect(afterOlderEdit.body).not.toContain("Older edit");
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with conflict",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Newer edit should overwrite",
+              author: "alice",
+              createdAt: "2026-03-10T03:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    const afterNewerEdit = issueClient.snapshotComments(repositoryTarget(), 1)[0];
+    expect(afterNewerEdit.body).toContain("Newer edit should overwrite");
+  });
+
+  it("maps one GitHub comment to one todu comment and vice versa", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with multiple comments",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 301,
+        issueNumber: 1,
+        body: "GitHub comment A",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+      createGitHubComment({
+        id: 302,
+        issueNumber: 1,
+        body: "GitHub comment B",
+        author: "bob",
+        createdAt: "2026-03-10T00:01:00.000Z",
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    const provider = createGitHubSyncProvider({ issueClient, linkStore, commentLinkStore });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.pull(binding, createProject());
+
+    expect(provider.getState().commentLinks).toHaveLength(2);
+    const links = provider.getState().commentLinks;
+    const externalIds = links.map((l) => l.githubCommentId);
+    expect(externalIds).toContain(301);
+    expect(externalIds).toContain(302);
+
+    const result = await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with multiple comments",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-push-1",
+              content: "Todu comment C",
+              author: "charlie",
+              createdAt: "2026-03-10T01:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(result.commentLinks).toHaveLength(1);
+    expect(result.commentLinks[0].localNoteId).toBe(createNoteId("note-push-1"));
+
+    const ghComments = issueClient.snapshotComments(repositoryTarget(), 1);
+    expect(ghComments).toHaveLength(3);
   });
 });
 
@@ -571,10 +1040,11 @@ function createTaskWithDetail(
   overrides: {
     id: string;
     title: string;
-    status: TaskWithDetail["status"];
+    status: TaskPushPayload["status"];
     description?: string;
-  } & Partial<Omit<TaskWithDetail, "id" | "title" | "status" | "description">>
-): TaskWithDetail {
+    comments?: Note[];
+  } & Partial<Omit<TaskPushPayload, "id" | "title" | "status" | "description" | "comments">>
+): TaskPushPayload {
   return {
     id: createTaskId(overrides.id),
     title: overrides.title,
@@ -586,6 +1056,7 @@ function createTaskWithDetail(
     externalId: overrides.externalId,
     sourceUrl: overrides.sourceUrl,
     description: overrides.description,
+    comments: overrides.comments ?? [],
     createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-03-10T00:00:00.000Z",
   };
@@ -614,6 +1085,40 @@ function createIssue(overrides: {
     createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-03-10T00:00:00.000Z",
     isPullRequest: overrides.isPullRequest,
+  };
+}
+
+function createNote(overrides: {
+  id: string;
+  content: string;
+  author: string;
+  createdAt?: string;
+}): Note {
+  return {
+    id: createNoteId(overrides.id),
+    content: overrides.content,
+    author: overrides.author,
+    tags: [],
+    createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
+  };
+}
+
+function createGitHubComment(overrides: {
+  id: number;
+  issueNumber: number;
+  body: string;
+  author: string;
+  createdAt?: string;
+  updatedAt?: string;
+}): GitHubComment {
+  return {
+    id: overrides.id,
+    issueNumber: overrides.issueNumber,
+    body: overrides.body,
+    author: overrides.author,
+    sourceUrl: `https://github.com/evcraddock/todu-github-plugin/issues/${overrides.issueNumber}#issuecomment-${overrides.id}`,
+    createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
+    updatedAt: overrides.updatedAt,
   };
 }
 

--- a/src/github-bootstrap.ts
+++ b/src/github-bootstrap.ts
@@ -1,4 +1,4 @@
-import type { ExternalTask, IntegrationBinding, TaskWithDetail } from "@todu/core";
+import type { ExternalTask, IntegrationBinding, TaskPushPayload } from "@todu/core";
 
 import type { GitHubIssue, GitHubIssueClient } from "@/github-client";
 import {
@@ -14,7 +14,7 @@ import {
 } from "@/github-links";
 import { parseIssueExternalId } from "@/github-ids";
 
-const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<TaskWithDetail["status"]>([
+const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<TaskPushPayload["status"]>([
   "active",
   "inprogress",
   "waiting",
@@ -26,7 +26,7 @@ export interface GitHubBootstrapImportResult {
 }
 
 export interface GitHubBootstrapTaskUpdate {
-  taskId: TaskWithDetail["id"];
+  taskId: TaskPushPayload["id"];
   externalId: string;
   sourceUrl?: string;
 }
@@ -82,7 +82,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
   binding: IntegrationBinding;
   owner: string;
   repo: string;
-  tasks: TaskWithDetail[];
+  tasks: TaskPushPayload[];
   issueClient: GitHubIssueClient;
   linkStore: GitHubItemLinkStore;
 }): Promise<GitHubBootstrapExportResult> {
@@ -203,7 +203,7 @@ function createIssueSourceUrl(owner: string, repo: string, issueNumber: number):
   return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
 }
 
-function shouldPushTaskUpdate(task: TaskWithDetail, issue: GitHubIssue | null): boolean {
+function shouldPushTaskUpdate(task: TaskPushPayload, issue: GitHubIssue | null): boolean {
   if (!issue?.updatedAt) {
     return true;
   }
@@ -219,7 +219,7 @@ function shouldPushTaskUpdate(task: TaskWithDetail, issue: GitHubIssue | null): 
 }
 
 function getMatchingExternalId(
-  task: TaskWithDetail,
+  task: TaskPushPayload,
   owner: string,
   repo: string
 ): { issueNumber: number } | null {

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -14,6 +14,16 @@ export interface GitHubIssue {
   isPullRequest?: boolean;
 }
 
+export interface GitHubComment {
+  id: number;
+  issueNumber: number;
+  body: string;
+  author: string;
+  sourceUrl?: string;
+  createdAt: string;
+  updatedAt?: string;
+}
+
 export interface CreateGitHubIssueInput {
   title: string;
   body?: string;
@@ -37,18 +47,41 @@ export interface GitHubIssueClient {
     issueNumber: number,
     input: UpdateGitHubIssueInput
   ): Promise<GitHubIssue>;
+  listComments(target: GitHubRepositoryTarget, issueNumber: number): Promise<GitHubComment[]>;
+  createComment(
+    target: GitHubRepositoryTarget,
+    issueNumber: number,
+    body: string
+  ): Promise<GitHubComment>;
+  updateComment(
+    target: GitHubRepositoryTarget,
+    commentId: number,
+    body: string
+  ): Promise<GitHubComment>;
+  deleteComment(target: GitHubRepositoryTarget, commentId: number): Promise<void>;
 }
 
 export interface InMemoryGitHubIssueClient extends GitHubIssueClient {
   seedIssues(target: GitHubRepositoryTarget, issues: GitHubIssue[]): void;
+  seedComments(
+    target: GitHubRepositoryTarget,
+    issueNumber: number,
+    comments: GitHubComment[]
+  ): void;
   snapshotIssues(target: GitHubRepositoryTarget): GitHubIssue[];
+  snapshotComments(target: GitHubRepositoryTarget, issueNumber: number): GitHubComment[];
 }
 
 export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
   const issuesByRepository = new Map<string, GitHubIssue[]>();
+  const commentsByIssue = new Map<string, GitHubComment[]>();
+  let nextCommentId = 1;
 
   const getRepositoryKey = (target: GitHubRepositoryTarget): string =>
     `${target.owner}/${target.repo}`;
+
+  const getCommentKey = (target: GitHubRepositoryTarget, issueNumber: number): string =>
+    `${getRepositoryKey(target)}#${issueNumber}`;
 
   const getIssues = (target: GitHubRepositoryTarget): GitHubIssue[] => {
     const repositoryKey = getRepositoryKey(target);
@@ -59,14 +92,53 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
     issuesByRepository.set(getRepositoryKey(target), issues);
   };
 
+  const getComments = (target: GitHubRepositoryTarget, issueNumber: number): GitHubComment[] =>
+    commentsByIssue.get(getCommentKey(target, issueNumber)) ?? [];
+
+  const setComments = (
+    target: GitHubRepositoryTarget,
+    issueNumber: number,
+    comments: GitHubComment[]
+  ): void => {
+    commentsByIssue.set(getCommentKey(target, issueNumber), comments);
+  };
+
   const cloneIssue = (issue: GitHubIssue): GitHubIssue => ({
     ...issue,
     labels: [...issue.labels],
     assignees: [...issue.assignees],
   });
 
+  const cloneComment = (comment: GitHubComment): GitHubComment => ({ ...comment });
+
   const createIssueSourceUrl = (target: GitHubRepositoryTarget, issueNumber: number): string =>
     `https://github.com/${target.owner}/${target.repo}/issues/${issueNumber}`;
+
+  const createCommentSourceUrl = (
+    target: GitHubRepositoryTarget,
+    issueNumber: number,
+    commentId: number
+  ): string =>
+    `https://github.com/${target.owner}/${target.repo}/issues/${issueNumber}#issuecomment-${commentId}`;
+
+  const findCommentById = (
+    target: GitHubRepositoryTarget,
+    commentId: number
+  ): { comments: GitHubComment[]; index: number; issueNumber: number } | null => {
+    for (const [key, comments] of commentsByIssue.entries()) {
+      if (!key.startsWith(getRepositoryKey(target))) {
+        continue;
+      }
+
+      const index = comments.findIndex((c) => c.id === commentId);
+      if (index !== -1) {
+        const issueNumber = comments[index].issueNumber;
+        return { comments, index, issueNumber };
+      }
+    }
+
+    return null;
+  };
 
   return {
     seedIssues(target, issues): void {
@@ -81,8 +153,28 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
         )
       );
     },
+    seedComments(target, issueNumber, comments): void {
+      const seeded = comments.map((comment) => {
+        const id = comment.id || nextCommentId++;
+        if (comment.id && comment.id >= nextCommentId) {
+          nextCommentId = comment.id + 1;
+        }
+
+        return cloneComment({
+          ...comment,
+          id,
+          issueNumber,
+          sourceUrl: comment.sourceUrl ?? createCommentSourceUrl(target, issueNumber, id),
+        });
+      });
+
+      setComments(target, issueNumber, seeded);
+    },
     snapshotIssues(target): GitHubIssue[] {
       return getIssues(target).map(cloneIssue);
+    },
+    snapshotComments(target, issueNumber): GitHubComment[] {
+      return getComments(target, issueNumber).map(cloneComment);
     },
     async listIssues(target): Promise<GitHubIssue[]> {
       return getIssues(target)
@@ -139,6 +231,54 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
       nextIssues[index] = updatedIssue;
       setIssues(target, nextIssues);
       return cloneIssue(updatedIssue);
+    },
+    async listComments(target, issueNumber): Promise<GitHubComment[]> {
+      return getComments(target, issueNumber).map(cloneComment);
+    },
+    async createComment(target, issueNumber, body): Promise<GitHubComment> {
+      const comments = getComments(target, issueNumber);
+      const commentId = nextCommentId++;
+      const timestamp = new Date().toISOString();
+      const created: GitHubComment = {
+        id: commentId,
+        issueNumber,
+        body,
+        author: "github-token-user",
+        sourceUrl: createCommentSourceUrl(target, issueNumber, commentId),
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      };
+
+      setComments(target, issueNumber, [...comments, created]);
+      return cloneComment(created);
+    },
+    async updateComment(target, commentId, body): Promise<GitHubComment> {
+      const found = findCommentById(target, commentId);
+      if (!found) {
+        throw new Error(
+          `GitHub comment not found: ${getRepositoryKey(target)} comment ${commentId}`
+        );
+      }
+
+      const existing = found.comments[found.index];
+      const updated: GitHubComment = {
+        ...existing,
+        body,
+        updatedAt: new Date().toISOString(),
+      };
+
+      found.comments[found.index] = updated;
+      return cloneComment(updated);
+    },
+    async deleteComment(target, commentId): Promise<void> {
+      const found = findCommentById(target, commentId);
+      if (!found) {
+        throw new Error(
+          `GitHub comment not found: ${getRepositoryKey(target)} comment ${commentId}`
+        );
+      }
+
+      found.comments.splice(found.index, 1);
     },
   };
 }

--- a/src/github-comment-links.ts
+++ b/src/github-comment-links.ts
@@ -1,0 +1,185 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import type { IntegrationBinding, NoteId } from "@todu/core";
+
+import type { Task } from "@todu/core";
+
+export interface GitHubCommentLink {
+  bindingId: IntegrationBinding["id"];
+  taskId: Task["id"];
+  noteId: NoteId;
+  issueNumber: number;
+  githubCommentId: number;
+  lastMirroredAt: string;
+}
+
+export interface GitHubCommentLinkStore {
+  getByNoteId(bindingId: IntegrationBinding["id"], noteId: NoteId): GitHubCommentLink | null;
+  getByGitHubCommentId(
+    bindingId: IntegrationBinding["id"],
+    githubCommentId: number
+  ): GitHubCommentLink | null;
+  listByIssue(bindingId: IntegrationBinding["id"], issueNumber: number): GitHubCommentLink[];
+  listByTask(bindingId: IntegrationBinding["id"], taskId: Task["id"]): GitHubCommentLink[];
+  listAll(): GitHubCommentLink[];
+  save(link: GitHubCommentLink): void;
+  remove(bindingId: IntegrationBinding["id"], noteId: NoteId): void;
+  removeByGitHubCommentId(bindingId: IntegrationBinding["id"], githubCommentId: number): void;
+}
+
+export function createInMemoryGitHubCommentLinkStore(): GitHubCommentLinkStore {
+  const links = new Map<string, GitHubCommentLink>();
+
+  const getNoteKey = (bindingId: IntegrationBinding["id"], noteId: NoteId): string =>
+    `note:${bindingId}:${noteId}`;
+  const getGitHubKey = (bindingId: IntegrationBinding["id"], githubCommentId: number): string =>
+    `gh:${bindingId}:${githubCommentId}`;
+
+  return {
+    getByNoteId(bindingId, noteId): GitHubCommentLink | null {
+      return links.get(getNoteKey(bindingId, noteId)) ?? null;
+    },
+    getByGitHubCommentId(bindingId, githubCommentId): GitHubCommentLink | null {
+      return links.get(getGitHubKey(bindingId, githubCommentId)) ?? null;
+    },
+    listByIssue(bindingId, issueNumber): GitHubCommentLink[] {
+      const result: GitHubCommentLink[] = [];
+      const seen = new Set<string>();
+      for (const link of links.values()) {
+        if (
+          link.bindingId === bindingId &&
+          link.issueNumber === issueNumber &&
+          !seen.has(link.noteId)
+        ) {
+          seen.add(link.noteId);
+          result.push(link);
+        }
+      }
+
+      return result;
+    },
+    listByTask(bindingId, taskId): GitHubCommentLink[] {
+      const result: GitHubCommentLink[] = [];
+      const seen = new Set<string>();
+      for (const link of links.values()) {
+        if (link.bindingId === bindingId && link.taskId === taskId && !seen.has(link.noteId)) {
+          seen.add(link.noteId);
+          result.push(link);
+        }
+      }
+
+      return result;
+    },
+    listAll(): GitHubCommentLink[] {
+      const allLinks = new Map<string, GitHubCommentLink>();
+      for (const link of links.values()) {
+        allLinks.set(`${link.bindingId}:${link.noteId}`, link);
+      }
+
+      return [...allLinks.values()];
+    },
+    save(link): void {
+      links.set(getNoteKey(link.bindingId, link.noteId), link);
+      links.set(getGitHubKey(link.bindingId, link.githubCommentId), link);
+    },
+    remove(bindingId, noteId): void {
+      const link = links.get(getNoteKey(bindingId, noteId));
+      if (link) {
+        links.delete(getNoteKey(bindingId, noteId));
+        links.delete(getGitHubKey(bindingId, link.githubCommentId));
+      }
+    },
+    removeByGitHubCommentId(bindingId, githubCommentId): void {
+      const link = links.get(getGitHubKey(bindingId, githubCommentId));
+      if (link) {
+        links.delete(getNoteKey(bindingId, link.noteId));
+        links.delete(getGitHubKey(bindingId, githubCommentId));
+      }
+    },
+  };
+}
+
+export function createFileGitHubCommentLinkStore(storagePath: string): GitHubCommentLinkStore {
+  const readLinks = (): GitHubCommentLink[] => {
+    if (!fs.existsSync(storagePath)) {
+      return [];
+    }
+
+    const rawContent = fs.readFileSync(storagePath, "utf8");
+    if (!rawContent.trim()) {
+      return [];
+    }
+
+    const parsedContent = JSON.parse(rawContent) as unknown;
+    if (!Array.isArray(parsedContent)) {
+      throw new Error(`Invalid GitHub comment link store at ${storagePath}: expected JSON array`);
+    }
+
+    return parsedContent.map((link) => {
+      if (!link || typeof link !== "object") {
+        throw new Error(`Invalid GitHub comment link store at ${storagePath}: invalid link record`);
+      }
+
+      return link as GitHubCommentLink;
+    });
+  };
+
+  const writeLinks = (links: GitHubCommentLink[]): void => {
+    fs.mkdirSync(path.dirname(storagePath), { recursive: true });
+    fs.writeFileSync(storagePath, `${JSON.stringify(links, null, 2)}\n`, "utf8");
+  };
+
+  return {
+    getByNoteId(bindingId, noteId): GitHubCommentLink | null {
+      return (
+        readLinks().find((link) => link.bindingId === bindingId && link.noteId === noteId) ?? null
+      );
+    },
+    getByGitHubCommentId(bindingId, githubCommentId): GitHubCommentLink | null {
+      return (
+        readLinks().find(
+          (link) => link.bindingId === bindingId && link.githubCommentId === githubCommentId
+        ) ?? null
+      );
+    },
+    listByIssue(bindingId, issueNumber): GitHubCommentLink[] {
+      return readLinks().filter(
+        (link) => link.bindingId === bindingId && link.issueNumber === issueNumber
+      );
+    },
+    listByTask(bindingId, taskId): GitHubCommentLink[] {
+      return readLinks().filter((link) => link.bindingId === bindingId && link.taskId === taskId);
+    },
+    listAll(): GitHubCommentLink[] {
+      return readLinks();
+    },
+    save(link): void {
+      const existing = readLinks().filter(
+        (existingLink) =>
+          !(
+            existingLink.bindingId === link.bindingId &&
+            (existingLink.noteId === link.noteId ||
+              existingLink.githubCommentId === link.githubCommentId)
+          )
+      );
+
+      existing.push(link);
+      writeLinks(existing);
+    },
+    remove(bindingId, noteId): void {
+      const existing = readLinks().filter(
+        (link) => !(link.bindingId === bindingId && link.noteId === noteId)
+      );
+
+      writeLinks(existing);
+    },
+    removeByGitHubCommentId(bindingId, githubCommentId): void {
+      const existing = readLinks().filter(
+        (link) => !(link.bindingId === bindingId && link.githubCommentId === githubCommentId)
+      );
+
+      writeLinks(existing);
+    },
+  };
+}

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -1,0 +1,357 @@
+import type {
+  ExternalComment,
+  IntegrationBinding,
+  Note,
+  NoteId,
+  SyncProviderPushCommentLink,
+  TaskPushPayload,
+} from "@todu/core";
+
+import type { GitHubComment, GitHubIssueClient } from "@/github-client";
+import type { GitHubCommentLink, GitHubCommentLinkStore } from "@/github-comment-links";
+import type { GitHubItemLink, GitHubItemLinkStore } from "@/github-links";
+import { formatIssueExternalId } from "@/github-ids";
+
+const GITHUB_ATTRIBUTION_PREFIX = "_Synced from GitHub comment by @";
+const TODU_ATTRIBUTION_PREFIX = "_Synced from todu comment by @";
+const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+Z_$/;
+const IMPORTED_COMMENT_LINK_PREFIX = "external:";
+
+export function formatGitHubAttribution(author: string, timestamp: string): string {
+  return `_Synced from GitHub comment by @${author} on ${timestamp}_`;
+}
+
+export function formatToduAttribution(author: string, timestamp: string): string {
+  return `_Synced from todu comment by @${author} on ${timestamp}_`;
+}
+
+export function formatAttributedBody(attribution: string, body: string): string {
+  return `${attribution}\n\n${body}`;
+}
+
+export function stripAttribution(body: string): string {
+  const lines = body.split("\n");
+  if (lines.length < 1) {
+    return body;
+  }
+
+  const firstLine = lines[0];
+  if (
+    (firstLine.startsWith(GITHUB_ATTRIBUTION_PREFIX) ||
+      firstLine.startsWith(TODU_ATTRIBUTION_PREFIX)) &&
+    ATTRIBUTION_SUFFIX_PATTERN.test(firstLine)
+  ) {
+    const remaining = lines.slice(1).join("\n");
+    return remaining.startsWith("\n") ? remaining.slice(1) : remaining;
+  }
+
+  return body;
+}
+
+export function hasGitHubAttribution(body: string): boolean {
+  const firstLine = body.split("\n")[0];
+  return (
+    firstLine.startsWith(GITHUB_ATTRIBUTION_PREFIX) && ATTRIBUTION_SUFFIX_PATTERN.test(firstLine)
+  );
+}
+
+function isImportedCommentLink(link: GitHubCommentLink): boolean {
+  return (link.noteId as string).startsWith(IMPORTED_COMMENT_LINK_PREFIX);
+}
+
+export interface PullCommentsResult {
+  comments: ExternalComment[];
+  createdLinks: GitHubCommentLink[];
+  deletedLinks: GitHubCommentLink[];
+}
+
+export async function pullComments(input: {
+  binding: IntegrationBinding;
+  owner: string;
+  repo: string;
+  issueClient: GitHubIssueClient;
+  itemLinkStore: GitHubItemLinkStore;
+  commentLinkStore: GitHubCommentLinkStore;
+}): Promise<PullCommentsResult> {
+  const comments: ExternalComment[] = [];
+  const createdLinks: GitHubCommentLink[] = [];
+  const deletedLinks: GitHubCommentLink[] = [];
+
+  const itemLinks = input.itemLinkStore.list(input.binding.id);
+
+  for (const itemLink of itemLinks) {
+    const githubComments = await input.issueClient.listComments(
+      { owner: input.owner, repo: input.repo },
+      itemLink.issueNumber
+    );
+    const existingCommentLinks = input.commentLinkStore.listByIssue(
+      input.binding.id,
+      itemLink.issueNumber
+    );
+
+    const githubCommentIds = new Set(githubComments.map((c) => c.id));
+
+    for (const commentLink of existingCommentLinks) {
+      if (!githubCommentIds.has(commentLink.githubCommentId)) {
+        input.commentLinkStore.removeByGitHubCommentId(
+          input.binding.id,
+          commentLink.githubCommentId
+        );
+        deletedLinks.push(commentLink);
+      }
+    }
+
+    for (const ghComment of githubComments) {
+      const externalTaskId = formatIssueExternalId({
+        owner: input.owner,
+        repo: input.repo,
+        issueNumber: itemLink.issueNumber,
+      });
+
+      const body = stripAttribution(ghComment.body);
+
+      comments.push({
+        externalId: String(ghComment.id),
+        externalTaskId,
+        body: formatAttributedBody(
+          formatGitHubAttribution(ghComment.author, ghComment.createdAt),
+          body
+        ),
+        author: ghComment.author,
+        createdAt: ghComment.createdAt,
+        updatedAt: ghComment.updatedAt,
+        raw: ghComment,
+      });
+
+      const existingLink = input.commentLinkStore.getByGitHubCommentId(
+        input.binding.id,
+        ghComment.id
+      );
+
+      if (!existingLink) {
+        const newLink: GitHubCommentLink = {
+          bindingId: input.binding.id,
+          taskId: itemLink.taskId,
+          noteId: `external:${ghComment.id}` as NoteId,
+          issueNumber: itemLink.issueNumber,
+          githubCommentId: ghComment.id,
+          lastMirroredAt: ghComment.updatedAt ?? ghComment.createdAt,
+        };
+
+        input.commentLinkStore.save(newLink);
+        createdLinks.push(newLink);
+      } else {
+        const updatedLink: GitHubCommentLink = {
+          ...existingLink,
+          lastMirroredAt: ghComment.updatedAt ?? ghComment.createdAt,
+        };
+
+        input.commentLinkStore.save(updatedLink);
+      }
+    }
+  }
+
+  return { comments, createdLinks, deletedLinks };
+}
+
+export interface PushCommentsResult {
+  commentLinks: SyncProviderPushCommentLink[];
+  createdComments: GitHubComment[];
+  updatedComments: GitHubComment[];
+  deletedCommentIds: number[];
+}
+
+export async function pushComments(input: {
+  binding: IntegrationBinding;
+  owner: string;
+  repo: string;
+  tasks: TaskPushPayload[];
+  issueClient: GitHubIssueClient;
+  itemLinkStore: GitHubItemLinkStore;
+  commentLinkStore: GitHubCommentLinkStore;
+}): Promise<PushCommentsResult> {
+  const commentLinks: SyncProviderPushCommentLink[] = [];
+  const createdComments: GitHubComment[] = [];
+  const updatedComments: GitHubComment[] = [];
+  const deletedCommentIds: number[] = [];
+
+  for (const task of input.tasks) {
+    const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.id);
+    if (!itemLink) {
+      continue;
+    }
+
+    const externalTaskId = formatIssueExternalId({
+      owner: input.owner,
+      repo: input.repo,
+      issueNumber: itemLink.issueNumber,
+    });
+
+    const existingCommentLinks = input.commentLinkStore.listByTask(input.binding.id, task.id);
+
+    const currentNoteIds = new Set(task.comments.map((c) => c.id));
+
+    for (const commentLink of existingCommentLinks) {
+      if (!currentNoteIds.has(commentLink.noteId) && !isImportedCommentLink(commentLink)) {
+        await deleteGitHubComment(input, commentLink, deletedCommentIds);
+      }
+    }
+
+    for (const note of task.comments) {
+      if (hasGitHubAttribution(note.content)) {
+        continue;
+      }
+
+      const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
+
+      if (existingLink) {
+        const updated = await updateGitHubCommentIfNeeded(
+          input,
+          note,
+          existingLink,
+          itemLink,
+          updatedComments
+        );
+        commentLinks.push(
+          createPushCommentLink(note.id, existingLink.githubCommentId, externalTaskId, updated)
+        );
+      } else {
+        const created = await createGitHubCommentFromNote(
+          input,
+          note,
+          task,
+          itemLink,
+          createdComments
+        );
+        commentLinks.push(createPushCommentLink(note.id, created.id, externalTaskId, created));
+      }
+    }
+  }
+
+  return { commentLinks, createdComments, updatedComments, deletedCommentIds };
+}
+
+async function deleteGitHubComment(
+  input: {
+    binding: IntegrationBinding;
+    owner: string;
+    repo: string;
+    issueClient: GitHubIssueClient;
+    commentLinkStore: GitHubCommentLinkStore;
+  },
+  commentLink: GitHubCommentLink,
+  deletedCommentIds: number[]
+): Promise<void> {
+  try {
+    await input.issueClient.deleteComment(
+      { owner: input.owner, repo: input.repo },
+      commentLink.githubCommentId
+    );
+  } catch {
+    // Comment may already be deleted on GitHub; proceed with link cleanup
+  }
+
+  input.commentLinkStore.remove(input.binding.id, commentLink.noteId);
+  deletedCommentIds.push(commentLink.githubCommentId);
+}
+
+async function updateGitHubCommentIfNeeded(
+  input: {
+    binding: IntegrationBinding;
+    owner: string;
+    repo: string;
+    issueClient: GitHubIssueClient;
+    commentLinkStore: GitHubCommentLinkStore;
+  },
+  note: Note,
+  existingLink: GitHubCommentLink,
+  _itemLink: GitHubItemLink,
+  updatedComments: GitHubComment[]
+): Promise<GitHubComment | null> {
+  const noteUpdatedAt = Date.parse(note.createdAt);
+  const lastMirroredAt = Date.parse(existingLink.lastMirroredAt);
+
+  if (
+    !Number.isNaN(noteUpdatedAt) &&
+    !Number.isNaN(lastMirroredAt) &&
+    noteUpdatedAt <= lastMirroredAt
+  ) {
+    return null;
+  }
+
+  const attributedBody = formatAttributedBody(
+    formatToduAttribution(note.author, note.createdAt),
+    note.content
+  );
+
+  const updated = await input.issueClient.updateComment(
+    { owner: input.owner, repo: input.repo },
+    existingLink.githubCommentId,
+    attributedBody
+  );
+
+  updatedComments.push(updated);
+
+  input.commentLinkStore.save({
+    ...existingLink,
+    lastMirroredAt: note.createdAt,
+  });
+
+  return updated;
+}
+
+async function createGitHubCommentFromNote(
+  input: {
+    binding: IntegrationBinding;
+    owner: string;
+    repo: string;
+    issueClient: GitHubIssueClient;
+    commentLinkStore: GitHubCommentLinkStore;
+  },
+  note: Note,
+  task: TaskPushPayload,
+  itemLink: GitHubItemLink,
+  createdComments: GitHubComment[]
+): Promise<GitHubComment> {
+  const attributedBody = formatAttributedBody(
+    formatToduAttribution(note.author, note.createdAt),
+    note.content
+  );
+
+  const created = await input.issueClient.createComment(
+    { owner: input.owner, repo: input.repo },
+    itemLink.issueNumber,
+    attributedBody
+  );
+
+  createdComments.push(created);
+
+  const newLink: GitHubCommentLink = {
+    bindingId: input.binding.id,
+    taskId: task.id,
+    noteId: note.id,
+    issueNumber: itemLink.issueNumber,
+    githubCommentId: created.id,
+    lastMirroredAt: note.createdAt,
+  };
+
+  input.commentLinkStore.save(newLink);
+
+  return created;
+}
+
+function createPushCommentLink(
+  noteId: NoteId,
+  githubCommentId: number,
+  externalTaskId: string,
+  comment: GitHubComment | null
+): SyncProviderPushCommentLink {
+  return {
+    localNoteId: noteId,
+    externalCommentId: String(githubCommentId),
+    externalTaskId,
+    sourceUrl: comment?.sourceUrl,
+    createdAt: comment?.createdAt,
+    updatedAt: comment?.updatedAt,
+  };
+}

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -5,9 +5,10 @@ import {
   type SyncProvider,
   type SyncProviderConfig,
   type SyncProviderPullResult,
+  type SyncProviderPushResult,
   type SyncProviderRegistration,
   type Task,
-  type TaskWithDetail,
+  type TaskPushPayload,
 } from "@todu/core";
 
 import {
@@ -22,6 +23,12 @@ import {
   parseGitHubBinding,
   type GitHubRepositoryBinding,
 } from "@/github-binding";
+import {
+  createInMemoryGitHubCommentLinkStore,
+  type GitHubCommentLink,
+  type GitHubCommentLinkStore,
+} from "@/github-comment-links";
+import { pullComments, pushComments } from "@/github-comments";
 import { loadGitHubProviderSettings, type GitHubProviderSettings } from "@/github-config";
 import { createImportedTaskId } from "@/github-ids";
 import {
@@ -41,6 +48,7 @@ export interface GitHubProviderState {
   initialized: boolean;
   settings: GitHubProviderSettings | null;
   itemLinks: GitHubItemLink[];
+  commentLinks: GitHubCommentLink[];
   lastPullResult: GitHubBootstrapImportResult | null;
   lastPushResult: GitHubBootstrapExportResult | null;
 }
@@ -52,6 +60,7 @@ export interface GitHubSyncProvider extends SyncProvider {
 export interface CreateGitHubSyncProviderOptions {
   issueClient?: GitHubIssueClient;
   linkStore?: GitHubItemLinkStore;
+  commentLinkStore?: GitHubCommentLinkStore;
 }
 
 export function createGitHubSyncProvider(
@@ -62,6 +71,7 @@ export function createGitHubSyncProvider(
   let lastPushResult: GitHubBootstrapExportResult | null = null;
   const issueClient = options.issueClient ?? createInMemoryGitHubIssueClient();
   let linkStore = options.linkStore ?? createInMemoryGitHubItemLinkStore();
+  const commentLinkStore = options.commentLinkStore ?? createInMemoryGitHubCommentLinkStore();
 
   const requireInitializedSettings = (): GitHubProviderSettings => {
     if (!settings) {
@@ -115,11 +125,21 @@ export function createGitHubSyncProvider(
         linkStore,
       });
 
+      const pullCommentsResult = await pullComments({
+        binding,
+        owner: parsedBinding.owner,
+        repo: parsedBinding.repo,
+        issueClient,
+        itemLinkStore: linkStore,
+        commentLinkStore,
+      });
+
       return {
         tasks: lastPullResult.tasks,
+        comments: pullCommentsResult.comments,
       };
     },
-    async push(binding, tasks: TaskWithDetail[], _project): Promise<void> {
+    async push(binding, tasks: TaskPushPayload[], _project): Promise<SyncProviderPushResult> {
       const parsedBinding = validateBinding(binding);
       if (binding.strategy === "none" || binding.strategy === "pull") {
         lastPushResult = {
@@ -128,7 +148,7 @@ export function createGitHubSyncProvider(
           createdLinks: [],
           taskUpdates: [],
         };
-        return;
+        return { commentLinks: [] };
       }
 
       lastPushResult = await bootstrapTasksToGitHubIssues({
@@ -139,6 +159,18 @@ export function createGitHubSyncProvider(
         issueClient,
         linkStore,
       });
+
+      const pushCommentsResult = await pushComments({
+        binding,
+        owner: parsedBinding.owner,
+        repo: parsedBinding.repo,
+        tasks,
+        issueClient,
+        itemLinkStore: linkStore,
+        commentLinkStore,
+      });
+
+      return { commentLinks: pushCommentsResult.commentLinks };
     },
     mapToTask(external: ExternalTask, project: Project): Task {
       return {
@@ -155,7 +187,7 @@ export function createGitHubSyncProvider(
         updatedAt: external.updatedAt ?? external.createdAt ?? DEFAULT_TIMESTAMP,
       };
     },
-    mapFromTask(task: TaskWithDetail): ExternalTask {
+    mapFromTask(task: TaskPushPayload): ExternalTask {
       return {
         externalId: task.externalId ?? String(task.id),
         title: task.title,
@@ -173,6 +205,7 @@ export function createGitHubSyncProvider(
         initialized: settings !== null,
         settings,
         itemLinks: linkStore.listAll(),
+        commentLinks: commentLinkStore.listAll(),
         lastPullResult,
         lastPushResult,
       };

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   createInMemoryGitHubIssueClient,
   type CreateGitHubIssueInput,
+  type GitHubComment,
   type GitHubIssue,
   type GitHubIssueClient,
   type InMemoryGitHubIssueClient,
@@ -64,3 +65,19 @@ export {
   type GitHubBootstrapImportResult,
   type GitHubBootstrapTaskUpdate,
 } from "@/github-bootstrap";
+export {
+  createFileGitHubCommentLinkStore,
+  createInMemoryGitHubCommentLinkStore,
+  type GitHubCommentLink,
+  type GitHubCommentLinkStore,
+} from "@/github-comment-links";
+export {
+  formatAttributedBody,
+  formatGitHubAttribution,
+  formatToduAttribution,
+  pullComments,
+  pushComments,
+  stripAttribution,
+  type PullCommentsResult,
+  type PushCommentsResult,
+} from "@/github-comments";


### PR DESCRIPTION
## Summary

Implement phase 4 from `docs/plans/phase-4-comment-sync.md` — bidirectional comment sync with strict 1:1 mirrored model.

## Changes

### New files
- `src/github-comment-links.ts` — Comment link storage (in-memory + file-backed) following the `github-links.ts` pattern
- `src/github-comments.ts` — Attribution formatting helpers and pull/push comment sync logic

### Modified files
- `package.json` — Update `@todu/core` to `^0.7.0` for `TaskPushPayload`, `ExternalComment`, `SyncProviderPushResult`
- `src/github-client.ts` — Add `GitHubComment` type and comment CRUD methods (`listComments`, `createComment`, `updateComment`, `deleteComment`)
- `src/github-provider.ts` — Wire comment sync into pull/push, update to `TaskPushPayload` and `SyncProviderPushResult`
- `src/github-bootstrap.ts` — Update push types from `TaskWithDetail` to `TaskPushPayload`
- `src/index.ts` — Re-export new comment modules

### Tests (8 new tests)
- Attribution formatting (GitHub and todu formats, strip, passthrough)
- Pull GitHub comments with attribution headers
- Push todu comments to GitHub with todu attribution
- Update mirrored GitHub comments on todu note edit
- Delete mirrored GitHub comments on todu note removal
- Detect deleted GitHub comments during pull
- Comment-level last-write-wins conflict resolution
- 1:1 comment mapping across both directions

## Design decisions
- **Attribution headers**: Visible `_Synced from {source} comment by @{author} on {timestamp}_` prefix on mirrored comments
- **Loop prevention**: Imported comments (with GitHub attribution) are skipped during push; placeholder comment links (`external:*`) are not deleted during push snapshot reconciliation
- **Conflict resolution**: Uses `note.createdAt` vs `lastMirroredAt` for comment-level last-write-wins
- **Snapshot-based sync**: Pull returns full comment snapshot for runtime reconciliation; push reconciles todu notes against comment links

## Acceptance Criteria
- [x] one GitHub comment maps to one todu comment and vice versa
- [x] mirrored comments include the expected attribution format
- [x] editing a comment on one side updates the mirrored comment on the other side
- [x] deleting a comment on one side deletes the mirrored comment on the other side
- [x] comment conflicts resolve according to the architecture rules
- [x] automated tests cover comment creation, edits, deletes, and conflict handling

Task: #2205