### PR TITLE
feat: implement incremental sync using GitHub since parameter

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -1514,7 +1514,9 @@ describe("multi-cycle steady-state sync", () => {
     expect(issueClient.snapshotIssues(repositoryTarget())).toHaveLength(2);
 
     const secondPull = await provider.pull(createBinding(), createProject());
-    expect(secondPull.tasks).toHaveLength(2);
+    // Incremental: only the newly created issue is returned (updated since last success)
+    expect(secondPull.tasks).toHaveLength(1);
+    expect(secondPull.tasks[0].title).toBe("New from todu");
   });
 
   it("updates from both sides converge after multiple cycles", async () => {
@@ -1561,6 +1563,130 @@ describe("multi-cycle steady-state sync", () => {
     expect(finalPull.tasks[0].title).toBe("Updated title");
     expect(finalPull.tasks[0].status).toBe("inprogress");
     expect(finalPull.tasks[0].priority).toBe("high");
+  });
+});
+
+describe("incremental sync", () => {
+  it("first pull fetches all issues (no since parameter)", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Old issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      createIssue({
+        number: 2,
+        title: "New issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    const result = await provider.pull(createBinding(), createProject());
+
+    expect(result.tasks).toHaveLength(2);
+  });
+
+  it("subsequent pull only fetches issues updated since last success", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Unchanged issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.tasks).toHaveLength(1);
+
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Unchanged issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      createIssue({
+        number: 2,
+        title: "Newly created issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    ]);
+
+    const secondPull = await provider.pull(createBinding(), createProject());
+    // Only the new issue is returned (updated after first pull's success timestamp)
+    expect(secondPull.tasks).toHaveLength(1);
+    expect(secondPull.tasks[0].title).toBe("Newly created issue");
+  });
+
+  it("pulls all issues after a failed cycle resets since", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ]);
+
+    let shouldFail = false;
+    const originalListIssues = issueClient.listIssues.bind(issueClient);
+    issueClient.listIssues = async (target, options) => {
+      if (shouldFail) {
+        throw new Error("transient");
+      }
+
+      return originalListIssues(target, options);
+    };
+
+    const runtimeStore = createInMemoryBindingRuntimeStore();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+      runtimeStore,
+      retryConfig: { initialSeconds: 0, maxSeconds: 0 },
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    // First pull succeeds, sets lastSuccessAt
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.tasks).toHaveLength(1);
+
+    // Second pull fails
+    shouldFail = true;
+    await expect(provider.pull(createBinding(), createProject())).rejects.toThrow();
+
+    // Failure doesn't update lastSuccessAt, so next pull still uses the old timestamp
+    shouldFail = false;
+    const thirdPull = await provider.pull(createBinding(), createProject());
+    // Issue hasn't changed since first success, so incremental returns nothing
+    expect(thirdPull.tasks).toHaveLength(0);
   });
 });
 

--- a/src/github-bootstrap.ts
+++ b/src/github-bootstrap.ts
@@ -44,11 +44,12 @@ export async function bootstrapGitHubIssuesToTasks(input: {
   repo: string;
   issueClient: GitHubIssueClient;
   linkStore: GitHubItemLinkStore;
+  since?: string;
 }): Promise<GitHubBootstrapImportResult> {
-  const issues = await input.issueClient.listIssues({
-    owner: input.owner,
-    repo: input.repo,
-  });
+  const issues = await input.issueClient.listIssues(
+    { owner: input.owner, repo: input.repo },
+    input.since ? { since: input.since } : undefined
+  );
 
   const tasks: ExternalTask[] = [];
   const createdLinks: GitHubItemLink[] = [];

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -38,8 +38,12 @@ export interface UpdateGitHubIssueInput {
   labels?: string[];
 }
 
+export interface ListIssuesOptions {
+  since?: string;
+}
+
 export interface GitHubIssueClient {
-  listIssues(target: GitHubRepositoryTarget): Promise<GitHubIssue[]>;
+  listIssues(target: GitHubRepositoryTarget, options?: ListIssuesOptions): Promise<GitHubIssue[]>;
   getIssue(target: GitHubRepositoryTarget, issueNumber: number): Promise<GitHubIssue | null>;
   createIssue(target: GitHubRepositoryTarget, input: CreateGitHubIssueInput): Promise<GitHubIssue>;
   updateIssue(
@@ -176,9 +180,16 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
     snapshotComments(target, issueNumber): GitHubComment[] {
       return getComments(target, issueNumber).map(cloneComment);
     },
-    async listIssues(target): Promise<GitHubIssue[]> {
+    async listIssues(target, options?): Promise<GitHubIssue[]> {
       return getIssues(target)
         .filter((issue) => !issue.isPullRequest)
+        .filter((issue) => {
+          if (!options?.since || !issue.updatedAt) {
+            return true;
+          }
+
+          return issue.updatedAt >= options.since;
+        })
         .map(cloneIssue);
     },
     async getIssue(target, issueNumber): Promise<GitHubIssue | null> {

--- a/src/github-http-client.ts
+++ b/src/github-http-client.ts
@@ -4,6 +4,7 @@ import type {
   GitHubComment,
   GitHubIssue,
   GitHubIssueClient,
+  ListIssuesOptions,
   UpdateGitHubIssueInput,
 } from "@/github-client";
 
@@ -126,8 +127,12 @@ export function createHttpGitHubIssueClient(token: string): GitHubIssueClient {
   };
 
   return {
-    async listIssues(target): Promise<GitHubIssue[]> {
-      const path = `/repos/${target.owner}/${target.repo}/issues?state=all`;
+    async listIssues(target, options?: ListIssuesOptions): Promise<GitHubIssue[]> {
+      let path = `/repos/${target.owner}/${target.repo}/issues?state=all`;
+      if (options?.since) {
+        path += `&since=${encodeURIComponent(options.since)}`;
+      }
+
       const rawIssues = await listAllPages<GitHubApiIssue>(path);
       return rawIssues.map((raw) => mapApiIssue(target, raw));
     },

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -207,6 +207,7 @@ export function createGitHubSyncProvider(
           repo: parsedBinding.repo,
           issueClient,
           linkStore,
+          since: runtimeState.lastSuccessAt ?? undefined,
         });
 
         const pullCommentsResult = await pullComments({

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   createInMemoryGitHubIssueClient,
   type CreateGitHubIssueInput,
+  type ListIssuesOptions,
   type GitHubComment,
   type GitHubIssue,
   type GitHubIssueClient,


### PR DESCRIPTION
## Summary

Implements incremental sync so the plugin only fetches issues updated since the last successful pull instead of downloading all issues every cycle.

## Changes

- Add `ListIssuesOptions` with optional `since` field to `GitHubIssueClient` interface
- HTTP client passes `since` to GitHub API `?since=` query parameter
- In-memory client filters by `updatedAt >= since` for test consistency
- Bootstrap import threads `since` through to `listIssues` call
- Provider reads `lastSuccessAt` from runtime store and passes as `since` on subsequent pulls
- First pull (no `lastSuccessAt`) does a full fetch
- 3 new tests for incremental sync behavior (111 total)

## Why

The plugin was downloading all issues from GitHub on every sync cycle. This wastes API calls and will burn through GitHub's rate limit (5,000 req/hr) on repos with many issues.

## Verification

- All checks passing (111 tests)

Task: #2251