### PR TITLE
chore: update @todu/core to 0.7.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "todu-github-plugin",
       "version": "0.1.0",
       "dependencies": {
-        "@todu/core": "^0.7.2"
+        "@todu/core": "^0.7.3"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1090,9 +1090,9 @@
       "license": "MIT"
     },
     "node_modules/@todu/core": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.7.2.tgz",
-      "integrity": "sha512-DXHyrrXJZMOfyhP4W2frML3UW+RrqF5oh5zOMjvencuPOFjAbEYCNySuAq183+w9J/bbn09YeQdc31Sv6X493g==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.7.3.tgz",
+      "integrity": "sha512-nvv1ilGr0Mtsx/oybuuDdkA423FbQNtmy2afMeLABfP9Vo9VIIDVPVaQLdUPKT2Z9Xn0WtRndqz0ONj9C/WT0g==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@todu/core": "^0.7.2"
+    "@todu/core": "^0.7.3"
   }
 }


### PR DESCRIPTION
## Summary

Update @todu/core from 0.7.2 to 0.7.3 to pick up the daemon-side fix for pulled comments (#2250): `applyPulledComments` now correctly maps `externalTaskId` to local task ID.

## Verification

- All 111 tests passing
- No breaking interface changes

Task: #2257