### PR TITLE
docs: use toduai plugin install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,16 +13,13 @@ npm install
 npm run build
 ```
 
-### 2. Register the plugin
+### 2. Install the plugin
 
-Add the built plugin path to your toduai daemon config under `daemon.plugins.paths`:
-
-```yaml
-daemon:
-  plugins:
-    paths:
-      - /absolute/path/to/todu-github-plugin/dist/index.js
+```bash
+toduai plugin install /absolute/path/to/todu-github-plugin/dist/index.js
 ```
+
+This registers the plugin with the toduai daemon. Use the actual path where you cloned the repo.
 
 ### 3. Configure your GitHub token
 


### PR DESCRIPTION
Replace manual yaml config edit with `toduai plugin install` CLI command for registering the plugin.

Task: #2261