### PR TITLE
fix: back off on github rate limit errors

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -14,6 +14,8 @@ import {
 } from "@todu/core";
 import { describe, expect, it } from "vitest";
 
+import { createGitHubApiError } from "@/github-http-client";
+
 import {
   GITHUB_PROVIDER_NAME,
   GITHUB_REPOSITORY_TARGET_KIND,
@@ -1124,6 +1126,85 @@ describe("runtime integration", () => {
     expect(state!.nextRetryAt).not.toBeNull();
 
     shouldFail = false;
+  });
+
+  it("uses GitHub rate-limit reset metadata to delay the next retry", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    const resetAt = new Date(Date.now() + 5 * 60 * 1000);
+    resetAt.setMilliseconds(0);
+    const resetAtHeader = String(Math.floor(resetAt.getTime() / 1000));
+
+    issueClient.listIssues = async () => {
+      const headers = new Headers({
+        "x-ratelimit-remaining": "0",
+        "x-ratelimit-reset": resetAtHeader,
+      });
+
+      throw createGitHubApiError({
+        status: 403,
+        method: "GET",
+        path: "/repos/evcraddock/todu-github-plugin/issues?state=all",
+        responseBody: '{"message":"API rate limit exceeded"}',
+        headers,
+      });
+    };
+
+    const runtimeStore = createInMemoryBindingRuntimeStore();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+      runtimeStore,
+      retryConfig: { initialSeconds: 5, maxSeconds: 60 },
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await expect(provider.pull(createBinding(), createProject())).rejects.toThrow(
+      "API rate limit exceeded"
+    );
+
+    const state = runtimeStore.get(createBinding().id);
+    expect(state).not.toBeNull();
+    expect(state!.retryAttempt).toBe(1);
+    expect(state!.nextRetryAt).toBe(resetAt.toISOString());
+    expect(state!.lastError).toContain(`retry after ${resetAt.toISOString()}`);
+
+    const status = provider.getState().bindingStatuses.get(createBinding().id);
+    expect(status?.lastErrorSummary).toContain(`retry after ${resetAt.toISOString()}`);
+  });
+
+  it("uses a long fallback cooldown when rate-limit metadata is unavailable", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.listIssues = async () => {
+      throw createGitHubApiError({
+        status: 403,
+        method: "GET",
+        path: "/repos/evcraddock/todu-github-plugin/issues?state=all",
+        responseBody: '{"message":"API rate limit exceeded"}',
+        headers: new Headers(),
+        now: new Date("2026-03-10T00:00:00.000Z"),
+      });
+    };
+
+    const runtimeStore = createInMemoryBindingRuntimeStore();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+      runtimeStore,
+      retryConfig: { initialSeconds: 5, maxSeconds: 60 },
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    await expect(provider.pull(createBinding(), createProject())).rejects.toThrow(
+      "API rate limit exceeded"
+    );
+
+    const state = runtimeStore.get(createBinding().id);
+    expect(state).not.toBeNull();
+
+    const retryDelayMs = Date.parse(state!.nextRetryAt!) - Date.parse(state!.lastAttemptAt!);
+    expect(retryDelayMs).toBe(15 * 60 * 1000);
+    expect(state!.lastError).toContain("retry delayed due to GitHub rate limit");
   });
 
   it("skips pull when retry backoff has not elapsed", async () => {

--- a/src/__tests__/github-runtime.test.ts
+++ b/src/__tests__/github-runtime.test.ts
@@ -123,6 +123,29 @@ describe("recordFailure", () => {
     const delay = computeNextRetryDelay(state.retryAttempt, config);
     expect(delay).toBe(300);
   });
+
+  it("accepts an explicit retryAt override", () => {
+    const now = new Date("2026-03-10T12:00:00.000Z");
+    const retryAt = new Date("2026-03-10T12:30:00.000Z");
+
+    const state = recordFailure(createInitialRuntimeState(BINDING_ID), "rate limit", config, now, {
+      retryAt,
+    });
+
+    expect(state.retryAttempt).toBe(1);
+    expect(state.nextRetryAt).toBe("2026-03-10T12:30:00.000Z");
+  });
+
+  it("accepts an explicit delay override", () => {
+    const now = new Date("2026-03-10T12:00:00.000Z");
+
+    const state = recordFailure(createInitialRuntimeState(BINDING_ID), "rate limit", config, now, {
+      delaySeconds: 900,
+    });
+
+    expect(state.retryAttempt).toBe(1);
+    expect(state.nextRetryAt).toBe("2026-03-10T12:15:00.000Z");
+  });
 });
 
 describe("shouldRetry", () => {

--- a/src/github-http-client.ts
+++ b/src/github-http-client.ts
@@ -30,6 +30,95 @@ interface GitHubApiComment {
   updated_at: string;
 }
 
+export class GitHubApiError extends Error {
+  readonly status: number;
+  readonly method: string;
+  readonly path: string;
+  readonly responseBody: string;
+  readonly isRateLimitError: boolean;
+  readonly retryAt: string | null;
+
+  constructor(input: {
+    status: number;
+    method: string;
+    path: string;
+    responseBody: string;
+    isRateLimitError: boolean;
+    retryAt: string | null;
+  }) {
+    super(`GitHub API ${input.method} ${input.path} failed: ${input.status} ${input.responseBody}`);
+    this.name = "GitHubApiError";
+    this.status = input.status;
+    this.method = input.method;
+    this.path = input.path;
+    this.responseBody = input.responseBody;
+    this.isRateLimitError = input.isRateLimitError;
+    this.retryAt = input.retryAt;
+  }
+}
+
+function parseRetryAtFromHeaders(headers: Headers, now: Date = new Date()): string | null {
+  const retryAfterHeader = headers.get("retry-after");
+  if (retryAfterHeader != null) {
+    const retryAfterSeconds = Number.parseInt(retryAfterHeader, 10);
+    if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds >= 0) {
+      return new Date(now.getTime() + retryAfterSeconds * 1000).toISOString();
+    }
+  }
+
+  const resetHeader = headers.get("x-ratelimit-reset");
+  if (resetHeader != null) {
+    const resetSeconds = Number.parseInt(resetHeader, 10);
+    if (!Number.isNaN(resetSeconds) && resetSeconds > 0) {
+      return new Date(resetSeconds * 1000).toISOString();
+    }
+  }
+
+  return null;
+}
+
+function isRateLimitResponse(status: number, headers: Headers, responseBody: string): boolean {
+  if (status === 429) {
+    return true;
+  }
+
+  if (status !== 403) {
+    return false;
+  }
+
+  const remainingHeader = headers.get("x-ratelimit-remaining");
+  if (remainingHeader === "0") {
+    return true;
+  }
+
+  return responseBody.toLowerCase().includes("rate limit exceeded");
+}
+
+export function createGitHubApiError(input: {
+  status: number;
+  method: string;
+  path: string;
+  responseBody: string;
+  headers: Headers;
+  now?: Date;
+}): GitHubApiError {
+  const now = input.now ?? new Date();
+  const rateLimitError = isRateLimitResponse(input.status, input.headers, input.responseBody);
+
+  return new GitHubApiError({
+    status: input.status,
+    method: input.method,
+    path: input.path,
+    responseBody: input.responseBody,
+    isRateLimitError: rateLimitError,
+    retryAt: rateLimitError ? parseRetryAtFromHeaders(input.headers, now) : null,
+  });
+}
+
+export function isGitHubRateLimitError(error: unknown): error is GitHubApiError {
+  return error instanceof GitHubApiError && error.isRateLimitError;
+}
+
 function normalizeLabels(labels: GitHubApiIssue["labels"]): string[] {
   return labels.map((label) => (typeof label === "string" ? label : label.name));
 }
@@ -93,7 +182,13 @@ export function createHttpGitHubIssueClient(token: string): GitHubIssueClient {
 
     if (!response.ok) {
       const text = await response.text().catch(() => "");
-      throw new Error(`GitHub API ${method} ${path} failed: ${response.status} ${text}`);
+      throw createGitHubApiError({
+        status: response.status,
+        method,
+        path,
+        responseBody: text,
+        headers: response.headers,
+      });
     }
 
     if (response.status === 204) {

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -31,7 +31,7 @@ import {
   type GitHubBootstrapImportResult,
 } from "@/github-bootstrap";
 import { createInMemoryGitHubIssueClient, type GitHubIssueClient } from "@/github-client";
-import { createHttpGitHubIssueClient } from "@/github-http-client";
+import { createHttpGitHubIssueClient, isGitHubRateLimitError } from "@/github-http-client";
 import {
   createInMemoryGitHubCommentLinkStore,
   type GitHubCommentLink,
@@ -73,6 +73,7 @@ const OPEN_TASK_STATUSES = new Set(["active", "inprogress", "waiting"]);
 const TASK_PRIORITIES = new Set(["low", "medium", "high"]);
 const DEFAULT_LOOP_PREVENTION_MAX_AGE_MS = 10 * 60 * 1000;
 const IMPORT_CLOSED_ON_BOOTSTRAP_OPTION = "importClosedOnBootstrap";
+const RATE_LIMIT_FALLBACK_DELAY_SECONDS = 15 * 60;
 
 export interface GitHubProviderState {
   initialized: boolean;
@@ -100,6 +101,37 @@ export interface CreateGitHubSyncProviderOptions {
 
 function isImportClosedOnBootstrapEnabled(binding: IntegrationBinding): boolean {
   return binding.options?.[IMPORT_CLOSED_ON_BOOTSTRAP_OPTION] === true;
+}
+
+function getRetryOverrideForError(
+  error: unknown
+): { delaySeconds?: number; retryAt?: Date } | undefined {
+  if (!isGitHubRateLimitError(error)) {
+    return undefined;
+  }
+
+  if (error.retryAt != null) {
+    const retryAt = new Date(error.retryAt);
+    if (!Number.isNaN(retryAt.getTime())) {
+      return { retryAt };
+    }
+  }
+
+  return { delaySeconds: RATE_LIMIT_FALLBACK_DELAY_SECONDS };
+}
+
+function getErrorSummary(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  if (isGitHubRateLimitError(error) && error.retryAt != null) {
+    return `${message} (retry after ${error.retryAt})`;
+  }
+
+  if (isGitHubRateLimitError(error)) {
+    return `${message} (retry delayed due to GitHub rate limit)`;
+  }
+
+  return message;
 }
 
 export function createGitHubSyncProvider(
@@ -243,15 +275,21 @@ export function createGitHubSyncProvider(
           comments: pullCommentsResult.comments,
         };
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const failedState = recordFailure(runtimeState, errorMessage, retryConfig);
+        const errorSummary = getErrorSummary(error);
+        const failedState = recordFailure(
+          runtimeState,
+          errorSummary,
+          retryConfig,
+          new Date(),
+          getRetryOverrideForError(error)
+        );
         runtimeStore.save(failedState);
         bindingStatuses.set(
           binding.id,
-          updateBindingStatusError(getOrCreateBindingStatus(binding.id), errorMessage)
+          updateBindingStatusError(getOrCreateBindingStatus(binding.id), errorSummary)
         );
 
-        logger.error("pull failed", logContext, errorMessage);
+        logger.error("pull failed", logContext, errorSummary);
         throw error;
       }
     },
@@ -352,15 +390,21 @@ export function createGitHubSyncProvider(
 
         return { commentLinks: pushCommentsResult.commentLinks, taskLinks };
       } catch (error) {
-        const errorMessage = error instanceof Error ? error.message : String(error);
-        const failedState = recordFailure(runtimeState, errorMessage, retryConfig);
+        const errorSummary = getErrorSummary(error);
+        const failedState = recordFailure(
+          runtimeState,
+          errorSummary,
+          retryConfig,
+          new Date(),
+          getRetryOverrideForError(error)
+        );
         runtimeStore.save(failedState);
         bindingStatuses.set(
           binding.id,
-          updateBindingStatusError(getOrCreateBindingStatus(binding.id), errorMessage)
+          updateBindingStatusError(getOrCreateBindingStatus(binding.id), errorSummary)
         );
 
-        logger.error("push failed", logContext, errorMessage);
+        logger.error("push failed", logContext, errorSummary);
         throw error;
       }
     },

--- a/src/github-runtime.ts
+++ b/src/github-runtime.ts
@@ -25,6 +25,11 @@ export interface RetryConfig {
   maxSeconds: number;
 }
 
+export interface RetryOverride {
+  delaySeconds?: number;
+  retryAt?: Date;
+}
+
 const DEFAULT_RETRY_CONFIG: RetryConfig = {
   initialSeconds: 5,
   maxSeconds: 300,
@@ -80,11 +85,16 @@ export function recordFailure(
   state: BindingRuntimeState,
   error: string,
   config: RetryConfig = DEFAULT_RETRY_CONFIG,
-  now: Date = new Date()
+  now: Date = new Date(),
+  retryOverride?: RetryOverride
 ): BindingRuntimeState {
   const nextAttempt = state.retryAttempt + 1;
-  const delaySeconds = computeNextRetryDelay(nextAttempt, config);
-  const nextRetryAt = new Date(now.getTime() + delaySeconds * 1000);
+  const delaySeconds = retryOverride?.delaySeconds ?? computeNextRetryDelay(nextAttempt, config);
+  const overrideRetryAt = retryOverride?.retryAt;
+  const nextRetryAt =
+    overrideRetryAt != null
+      ? new Date(Math.max(overrideRetryAt.getTime(), now.getTime()))
+      : new Date(now.getTime() + delaySeconds * 1000);
 
   return {
     ...state,

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ export {
   type BindingRuntimeState,
   type BindingRuntimeStore,
   type RetryConfig,
+  type RetryOverride,
 } from "@/github-runtime";
 export {
   createLoopPreventionStore,


### PR DESCRIPTION
## Summary
- detect GitHub rate-limit responses using HTTP status, headers, and response body
- back off until the reported reset time when metadata is available, with a 15 minute fallback cooldown otherwise
- surface retry timing in the binding error summary and add tests for the new retry behavior

## Verification
- ./scripts/pre-pr.sh

Task: #2315