### PR TITLE
fix: fetch comments only for changed issues

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -870,7 +870,7 @@ describe("comment sync", () => {
     expect(provider.getState().commentLinks).toHaveLength(0);
   });
 
-  it("detects deleted GitHub comments during pull and removes comment links", async () => {
+  it("detects deleted GitHub comments during pull for issues changed in the current cycle", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.seedIssues(repositoryTarget(), [
       createIssue({
@@ -878,6 +878,7 @@ describe("comment sync", () => {
         title: "Issue with comment to delete on GitHub",
         state: "open",
         labels: ["status:active", "priority:medium"],
+        updatedAt: "2026-03-10T00:00:00.000Z",
       }),
     ]);
     issueClient.seedComments(repositoryTarget(), 1, [
@@ -900,6 +901,15 @@ describe("comment sync", () => {
     expect(provider.getState().commentLinks).toHaveLength(1);
 
     await issueClient.deleteComment(repositoryTarget(), 200);
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with comment to delete on GitHub",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+        updatedAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    ]);
 
     const secondPull = await provider.pull(createBinding(), createProject());
     expect(secondPull.comments).toHaveLength(0);
@@ -1905,6 +1915,130 @@ describe("incremental sync", () => {
     // Only the new issue is returned (updated after first pull's success timestamp)
     expect(secondPull.tasks).toHaveLength(1);
     expect(secondPull.tasks[0].title).toBe("Newly created issue");
+  });
+
+  it("subsequent pull only fetches comments for issues changed in the current cycle", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Unchanged issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      createIssue({
+        number: 2,
+        title: "Changed issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Comment on unchanged issue",
+        author: "octocat",
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 2, [
+      createGitHubComment({
+        id: 200,
+        issueNumber: 2,
+        body: "Comment on changed issue",
+        author: "octocat",
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    const listCommentsCalls: number[] = [];
+    const originalListComments = issueClient.listComments.bind(issueClient);
+    issueClient.listComments = async (target, issueNumber) => {
+      listCommentsCalls.push(issueNumber);
+      return originalListComments(target, issueNumber);
+    };
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.comments).toHaveLength(2);
+    listCommentsCalls.length = 0;
+
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Unchanged issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      createIssue({
+        number: 2,
+        title: "Changed issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    ]);
+
+    const secondPull = await provider.pull(createBinding(), createProject());
+
+    expect(listCommentsCalls).toEqual([2]);
+    expect(secondPull.tasks).toHaveLength(1);
+    expect(secondPull.tasks[0].title).toBe("Changed issue");
+    expect(secondPull.comments).toHaveLength(1);
+    expect(secondPull.comments?.[0].externalTaskId).toBe("evcraddock/todu-github-plugin#2");
+  });
+
+  it("subsequent pull skips comment fetches when no issues changed", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Unchanged issue",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Existing comment",
+        author: "octocat",
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    const listCommentsCalls: number[] = [];
+    const originalListComments = issueClient.listComments.bind(issueClient);
+    issueClient.listComments = async (target, issueNumber) => {
+      listCommentsCalls.push(issueNumber);
+      return originalListComments(target, issueNumber);
+    };
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.comments).toHaveLength(1);
+    listCommentsCalls.length = 0;
+
+    const secondPull = await provider.pull(createBinding(), createProject());
+
+    expect(secondPull.tasks).toHaveLength(0);
+    expect(secondPull.comments).toHaveLength(0);
+    expect(listCommentsCalls).toEqual([]);
   });
 
   it("pulls all issues after a failed cycle resets since", async () => {

--- a/src/github-bootstrap.ts
+++ b/src/github-bootstrap.ts
@@ -23,6 +23,7 @@ const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<TaskPushPayload["status"]>([
 export interface GitHubBootstrapImportResult {
   tasks: ExternalTask[];
   createdLinks: GitHubItemLink[];
+  touchedIssueNumbers: number[];
 }
 
 export interface GitHubBootstrapTaskUpdate {
@@ -54,6 +55,7 @@ export async function bootstrapGitHubIssuesToTasks(input: {
 
   const tasks: ExternalTask[] = [];
   const createdLinks: GitHubItemLink[] = [];
+  const touchedIssueNumbers: number[] = [];
 
   for (const issue of issues) {
     if (issue.isPullRequest) {
@@ -72,11 +74,13 @@ export async function bootstrapGitHubIssuesToTasks(input: {
     }
 
     tasks.push(mapGitHubIssueToExternalTask(issue));
+    touchedIssueNumbers.push(issue.number);
   }
 
   return {
     tasks,
     createdLinks,
+    touchedIssueNumbers,
   };
 }
 

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -77,12 +77,16 @@ export async function pullComments(input: {
   issueClient: GitHubIssueClient;
   itemLinkStore: GitHubItemLinkStore;
   commentLinkStore: GitHubCommentLinkStore;
+  issueNumbers?: readonly number[];
 }): Promise<PullCommentsResult> {
   const comments: ExternalComment[] = [];
   const createdLinks: GitHubCommentLink[] = [];
   const deletedLinks: GitHubCommentLink[] = [];
 
-  const itemLinks = input.itemLinkStore.list(input.binding.id);
+  const issueNumbers = input.issueNumbers ? new Set(input.issueNumbers) : null;
+  const itemLinks = input.itemLinkStore
+    .list(input.binding.id)
+    .filter((itemLink) => issueNumbers?.has(itemLink.issueNumber) ?? true);
 
   for (const itemLink of itemLinks) {
     const githubComments = await input.issueClient.listComments(

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -220,7 +220,7 @@ export function createGitHubSyncProvider(
       const logContext = createLogContext(binding, parsedBinding, "pull");
 
       if (binding.strategy === "none" || binding.strategy === "push") {
-        lastPullResult = { tasks: [], createdLinks: [] };
+        lastPullResult = { tasks: [], createdLinks: [], touchedIssueNumbers: [] };
         logger.debug("skipping pull due to binding strategy", logContext);
         return { tasks: [] };
       }
@@ -256,6 +256,7 @@ export function createGitHubSyncProvider(
           issueClient,
           itemLinkStore: linkStore,
           commentLinkStore,
+          issueNumbers: lastPullResult.touchedIssueNumbers,
         });
 
         const updatedRuntimeState = recordSuccess(runtimeState, null);


### PR DESCRIPTION
## Summary

Reduce steady-state GitHub API usage by narrowing comment pulls to issues touched by the current changed-issues query.

## Task

- #2415

## Changes

- extend bootstrap pull results with touched issue numbers
- pass the touched issue set into comment pulling so unchanged linked issues are skipped
- update provider tests to cover narrowed comment fetching and changed-issue delete detection

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included