### PR TITLE
feat: disable comment deletion and add since-based comment fetching

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -725,9 +725,9 @@ describe("local provider state persistence", () => {
 
     const listCommentsCalls: number[] = [];
     const originalListComments = issueClient.listComments.bind(issueClient);
-    issueClient.listComments = async (target, issueNumber) => {
+    issueClient.listComments = async (target, issueNumber, options) => {
       listCommentsCalls.push(issueNumber);
-      return originalListComments(target, issueNumber);
+      return originalListComments(target, issueNumber, options);
     };
 
     await expect(secondProvider.pull(createBinding(), createProject())).resolves.toEqual({
@@ -1024,12 +1024,12 @@ describe("comment sync", () => {
     expect(ghComments[0].body).not.toContain("Original content");
   });
 
-  it("deletes mirrored GitHub comment when todu note is removed", async () => {
+  it("does not delete GitHub comment when todu note is removed", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.seedIssues(repositoryTarget(), [
       createIssue({
         number: 1,
-        title: "Issue with deletable comment",
+        title: "Issue with retained comment",
         state: "open",
         labels: ["status:active", "priority:medium"],
       }),
@@ -1050,12 +1050,12 @@ describe("comment sync", () => {
       [
         createTaskWithDetail({
           id: "task-1",
-          title: "Issue with deletable comment",
+          title: "Issue with retained comment",
           status: "active",
           comments: [
             createNote({
               id: "note-1",
-              content: "To be deleted",
+              content: "Pushed to GitHub",
               author: "alice",
               createdAt: "2026-03-10T01:00:00.000Z",
             }),
@@ -1072,7 +1072,7 @@ describe("comment sync", () => {
       [
         createTaskWithDetail({
           id: "task-1",
-          title: "Issue with deletable comment",
+          title: "Issue with retained comment",
           status: "active",
           comments: [],
         }),
@@ -1080,16 +1080,18 @@ describe("comment sync", () => {
       createProject()
     );
 
-    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(0);
-    expect(provider.getState().commentLinks).toHaveLength(0);
+    // Comment is retained on GitHub — deletion during sync is disabled
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+    // Comment link is also retained
+    expect(provider.getState().commentLinks).toHaveLength(1);
   });
 
-  it("detects deleted GitHub comments during pull for issues changed in the current cycle", async () => {
+  it("preserves comment link when GitHub comment is deleted (deletion detection is disabled)", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.seedIssues(repositoryTarget(), [
       createIssue({
         number: 1,
-        title: "Issue with comment to delete on GitHub",
+        title: "Issue with deleted GitHub comment",
         state: "open",
         labels: ["status:active", "priority:medium"],
         updatedAt: "2026-03-10T00:00:00.000Z",
@@ -1099,7 +1101,7 @@ describe("comment sync", () => {
       createGitHubComment({
         id: 200,
         issueNumber: 1,
-        body: "Will be deleted",
+        body: "Will be deleted on GitHub",
         author: "octocat",
         createdAt: "2026-03-10T00:00:00.000Z",
       }),
@@ -1118,7 +1120,7 @@ describe("comment sync", () => {
     issueClient.seedIssues(repositoryTarget(), [
       createIssue({
         number: 1,
-        title: "Issue with comment to delete on GitHub",
+        title: "Issue with deleted GitHub comment",
         state: "open",
         labels: ["status:active", "priority:medium"],
         updatedAt: new Date(Date.now() + 60_000).toISOString(),
@@ -1126,8 +1128,10 @@ describe("comment sync", () => {
     ]);
 
     const secondPull = await provider.pull(createBinding(), createProject());
+    // No comment returned (deleted + filtered by since)
     expect(secondPull.comments).toHaveLength(0);
-    expect(provider.getState().commentLinks).toHaveLength(0);
+    // Link is preserved — we no longer detect or clean up deleted GitHub comments
+    expect(provider.getState().commentLinks).toHaveLength(1);
   });
 
   it("resolves comment edit conflicts with last-write-wins using timestamps", async () => {
@@ -2180,9 +2184,9 @@ describe("incremental sync", () => {
 
     const listCommentsCalls: number[] = [];
     const originalListComments = issueClient.listComments.bind(issueClient);
-    issueClient.listComments = async (target, issueNumber) => {
+    issueClient.listComments = async (target, issueNumber, options) => {
       listCommentsCalls.push(issueNumber);
-      return originalListComments(target, issueNumber);
+      return originalListComments(target, issueNumber, options);
     };
 
     await provider.initialize({ settings: { token: "secret-token" } });
@@ -2210,11 +2214,13 @@ describe("incremental sync", () => {
 
     const secondPull = await provider.pull(createBinding(), createProject());
 
+    // Only changed issue #2 triggers a listComments call
     expect(listCommentsCalls).toEqual([2]);
     expect(secondPull.tasks).toHaveLength(1);
     expect(secondPull.tasks[0].title).toBe("Changed issue");
-    expect(secondPull.comments).toHaveLength(1);
-    expect(secondPull.comments?.[0].externalTaskId).toBe("evcraddock/todu-github-plugin#2");
+    // The existing comment on issue #2 was created before lastSuccessAt, so since-filtering
+    // excludes it — only genuinely new/updated comments are returned
+    expect(secondPull.comments).toHaveLength(0);
   });
 
   it("subsequent pull skips comment fetches when no issues changed", async () => {
@@ -2260,6 +2266,67 @@ describe("incremental sync", () => {
     expect(secondPull.tasks).toHaveLength(0);
     expect(secondPull.comments).toHaveLength(0);
     expect(listCommentsCalls).toEqual([]);
+  });
+
+  it("passes lastSuccessAt as since to listComments on subsequent pull", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with comments",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Old comment",
+        author: "octocat",
+        createdAt: "2026-03-01T00:00:00.000Z",
+        updatedAt: "2026-03-01T00:00:00.000Z",
+      }),
+    ]);
+
+    const runtimeStore = createInMemoryBindingRuntimeStore();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+      runtimeStore,
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    // First pull: no since, fetches all comments
+    const firstPull = await provider.pull(createBinding(), createProject());
+    expect(firstPull.comments).toHaveLength(1);
+
+    const capturedOptions: Array<{ since?: string }> = [];
+    const originalListComments = issueClient.listComments.bind(issueClient);
+    issueClient.listComments = async (target, issueNumber, options) => {
+      capturedOptions.push(options ?? {});
+      return originalListComments(target, issueNumber, options);
+    };
+
+    // Issue changes so it appears in next pull
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with comments",
+        state: "open",
+        labels: ["status:active"],
+        updatedAt: new Date(Date.now() + 120_000).toISOString(),
+      }),
+    ]);
+
+    await provider.pull(createBinding(), createProject());
+
+    const lastSuccessAt = runtimeStore.get(createBinding().id)?.lastSuccessAt;
+    expect(lastSuccessAt).toBeTruthy();
+    expect(capturedOptions).toHaveLength(1);
+    expect(capturedOptions[0].since).toBe(lastSuccessAt);
   });
 
   it("pulls all issues after a failed cycle resets since", async () => {

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -42,6 +42,10 @@ export interface ListIssuesOptions {
   since?: string;
 }
 
+export interface ListCommentsOptions {
+  since?: string;
+}
+
 export interface GitHubIssueClient {
   listIssues(target: GitHubRepositoryTarget, options?: ListIssuesOptions): Promise<GitHubIssue[]>;
   getIssue(target: GitHubRepositoryTarget, issueNumber: number): Promise<GitHubIssue | null>;
@@ -51,7 +55,11 @@ export interface GitHubIssueClient {
     issueNumber: number,
     input: UpdateGitHubIssueInput
   ): Promise<GitHubIssue>;
-  listComments(target: GitHubRepositoryTarget, issueNumber: number): Promise<GitHubComment[]>;
+  listComments(
+    target: GitHubRepositoryTarget,
+    issueNumber: number,
+    options?: ListCommentsOptions
+  ): Promise<GitHubComment[]>;
   createComment(
     target: GitHubRepositoryTarget,
     issueNumber: number,
@@ -243,8 +251,17 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
       setIssues(target, nextIssues);
       return cloneIssue(updatedIssue);
     },
-    async listComments(target, issueNumber): Promise<GitHubComment[]> {
-      return getComments(target, issueNumber).map(cloneComment);
+    async listComments(target, issueNumber, options?): Promise<GitHubComment[]> {
+      return getComments(target, issueNumber)
+        .filter((comment) => {
+          if (!options?.since) {
+            return true;
+          }
+
+          const commentTime = comment.updatedAt ?? comment.createdAt;
+          return commentTime >= options.since;
+        })
+        .map(cloneComment);
     },
     async createComment(target, issueNumber, body): Promise<GitHubComment> {
       const comments = getComments(target, issueNumber);

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -15,7 +15,6 @@ import { formatIssueExternalId } from "@/github-ids";
 const GITHUB_ATTRIBUTION_PREFIX = "_Synced from GitHub comment by @";
 const TODU_ATTRIBUTION_PREFIX = "_Synced from todu comment by @";
 const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+Z_$/;
-const IMPORTED_COMMENT_LINK_PREFIX = "external:";
 const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 
 export function formatGitHubAttribution(author: string, timestamp: string): string {
@@ -56,10 +55,6 @@ export function hasGitHubAttribution(body: string): boolean {
   );
 }
 
-function isImportedCommentLink(link: GitHubCommentLink): boolean {
-  return (link.noteId as string).startsWith(IMPORTED_COMMENT_LINK_PREFIX);
-}
-
 function hasImportedGitHubSyncTag(note: Note): boolean {
   return note.tags.some((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
 }
@@ -67,7 +62,6 @@ function hasImportedGitHubSyncTag(note: Note): boolean {
 export interface PullCommentsResult {
   comments: ExternalComment[];
   createdLinks: GitHubCommentLink[];
-  deletedLinks: GitHubCommentLink[];
 }
 
 export async function pullComments(input: {
@@ -78,10 +72,10 @@ export async function pullComments(input: {
   itemLinkStore: GitHubItemLinkStore;
   commentLinkStore: GitHubCommentLinkStore;
   issueNumbers?: readonly number[];
+  since?: string;
 }): Promise<PullCommentsResult> {
   const comments: ExternalComment[] = [];
   const createdLinks: GitHubCommentLink[] = [];
-  const deletedLinks: GitHubCommentLink[] = [];
 
   const issueNumbers = input.issueNumbers ? new Set(input.issueNumbers) : null;
   const itemLinks = input.itemLinkStore
@@ -91,24 +85,9 @@ export async function pullComments(input: {
   for (const itemLink of itemLinks) {
     const githubComments = await input.issueClient.listComments(
       { owner: input.owner, repo: input.repo },
-      itemLink.issueNumber
+      itemLink.issueNumber,
+      input.since ? { since: input.since } : undefined
     );
-    const existingCommentLinks = input.commentLinkStore.listByIssue(
-      input.binding.id,
-      itemLink.issueNumber
-    );
-
-    const githubCommentIds = new Set(githubComments.map((c) => c.id));
-
-    for (const commentLink of existingCommentLinks) {
-      if (!githubCommentIds.has(commentLink.githubCommentId)) {
-        input.commentLinkStore.removeByGitHubCommentId(
-          input.binding.id,
-          commentLink.githubCommentId
-        );
-        deletedLinks.push(commentLink);
-      }
-    }
 
     for (const ghComment of githubComments) {
       const externalTaskId = formatIssueExternalId({
@@ -157,14 +136,13 @@ export async function pullComments(input: {
     }
   }
 
-  return { comments, createdLinks, deletedLinks };
+  return { comments, createdLinks };
 }
 
 export interface PushCommentsResult {
   commentLinks: SyncProviderPushCommentLink[];
   createdComments: GitHubComment[];
   updatedComments: GitHubComment[];
-  deletedCommentIds: number[];
 }
 
 export async function pushComments(input: {
@@ -179,7 +157,6 @@ export async function pushComments(input: {
   const commentLinks: SyncProviderPushCommentLink[] = [];
   const createdComments: GitHubComment[] = [];
   const updatedComments: GitHubComment[] = [];
-  const deletedCommentIds: number[] = [];
 
   for (const task of input.tasks) {
     const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.id);
@@ -188,16 +165,6 @@ export async function pushComments(input: {
     }
 
     const localTaskId = task.id;
-
-    const existingCommentLinks = input.commentLinkStore.listByTask(input.binding.id, task.id);
-
-    const currentNoteIds = new Set(task.comments.map((c) => c.id));
-
-    for (const commentLink of existingCommentLinks) {
-      if (!currentNoteIds.has(commentLink.noteId) && !isImportedCommentLink(commentLink)) {
-        await deleteGitHubComment(input, commentLink, deletedCommentIds);
-      }
-    }
 
     for (const note of task.comments) {
       const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
@@ -230,31 +197,7 @@ export async function pushComments(input: {
     }
   }
 
-  return { commentLinks, createdComments, updatedComments, deletedCommentIds };
-}
-
-async function deleteGitHubComment(
-  input: {
-    binding: IntegrationBinding;
-    owner: string;
-    repo: string;
-    issueClient: GitHubIssueClient;
-    commentLinkStore: GitHubCommentLinkStore;
-  },
-  commentLink: GitHubCommentLink,
-  deletedCommentIds: number[]
-): Promise<void> {
-  try {
-    await input.issueClient.deleteComment(
-      { owner: input.owner, repo: input.repo },
-      commentLink.githubCommentId
-    );
-  } catch {
-    // Comment may already be deleted on GitHub; proceed with link cleanup
-  }
-
-  input.commentLinkStore.remove(input.binding.id, commentLink.noteId);
-  deletedCommentIds.push(commentLink.githubCommentId);
+  return { commentLinks, createdComments, updatedComments };
 }
 
 async function updateGitHubCommentIfNeeded(

--- a/src/github-http-client.ts
+++ b/src/github-http-client.ts
@@ -282,8 +282,12 @@ export function createHttpGitHubIssueClient(token: string): GitHubIssueClient {
       return mapApiIssue(target, raw);
     },
 
-    async listComments(target, issueNumber): Promise<GitHubComment[]> {
-      const path = `/repos/${target.owner}/${target.repo}/issues/${issueNumber}/comments`;
+    async listComments(target, issueNumber, options?): Promise<GitHubComment[]> {
+      let path = `/repos/${target.owner}/${target.repo}/issues/${issueNumber}/comments`;
+      if (options?.since) {
+        path += `?since=${encodeURIComponent(options.since)}`;
+      }
+
       const rawComments = await listAllPages<GitHubApiComment>(path);
       return rawComments.map((raw) => mapApiComment(target, issueNumber, raw));
     },

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -284,6 +284,7 @@ export function createGitHubSyncProvider(
           itemLinkStore: linkStore,
           commentLinkStore,
           issueNumbers: lastPullResult.touchedIssueNumbers,
+          since: runtimeState.lastSuccessAt ?? undefined,
         });
 
         const updatedRuntimeState = recordSuccess(runtimeState, null);
@@ -416,8 +417,7 @@ export function createGitHubSyncProvider(
             `${lastPushResult.skippedLinkedTasks} skipped, ` +
             `${lastPushResult.issueReadCount} issue reads, ` +
             `${pushCommentsResult.createdComments.length} comment creates, ` +
-            `${pushCommentsResult.updatedComments.length} comment updates, ` +
-            `${pushCommentsResult.deletedCommentIds.length} comment deletes`,
+            `${pushCommentsResult.updatedComments.length} comment updates`,
         });
 
         const taskLinks = lastPushResult.createdLinks.map((link) => ({


### PR DESCRIPTION
## Summary

Reduces GitHub API usage by eliminating full comment list fetches in steady-state sync cycles.

## Changes

### Disable comment deletion during sync
- Removed deletion detection from `pullComments` — no longer scans the full comment list to detect removed GitHub comments
- Removed orphan comment deletion from `pushComments` — GitHub comments are no longer deleted when a todu note is removed
- Removed `deleteGitHubComment` helper and `isImportedCommentLink` function (dead code)
- Dropped `deletedLinks` from `PullCommentsResult` and `deletedCommentIds` from `PushCommentsResult`

### Add `since`-based comment fetching
- Added `since?: string` option to `GitHubIssueClient.listComments` interface
- Implemented `?since=<encoded>` query param in `createHttpGitHubIssueClient`
- In-memory client filters comments by `since` (ISO string comparison) for test correctness
- `pullComments` accepts `since` and passes it to each `listComments` call
- Provider passes `runtimeState.lastSuccessAt ?? undefined` as `since`

## Effect

In steady state, `listComments` returns only comments created/updated since the last successful sync — typically zero for quiescent issues. Catch-up (first sync after restart, `lastSuccessAt` is null) continues to fetch all comments unchanged.

## Test updates
- Renamed deletion tests to describe the new retained-comment behavior
- Updated `listComments` spies to pass `options` through so `since` filtering works in tests
- Added test: _passes lastSuccessAt as since to listComments on subsequent pull_

Task: #2434