### PR TITLE
Finish GitHub actor-sync and stale-link fixes

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -344,16 +344,18 @@ If a label to be pushed to GitHub does not exist in the repo, the plugin automat
 
 ## Assignee Mapping
 
-Assignee sync is asymmetric.
+Assignee sync is bidirectional.
 
 ### GitHub to todu
 
-- GitHub assignees sync into todu.
-- If multiple GitHub assignees exist, they are joined into plain text in the todu assignee field.
+- GitHub assignees sync into todu as structured external actor refs.
+- Stable GitHub account ids, login names, and display names are preserved where available.
 
 ### Todu to GitHub
 
-- Todu assignees do not sync to GitHub.
+- Mapped local assignees sync back to GitHub.
+- Outbound assignee writes are login-based because GitHub issue assignment uses logins.
+- Assignees without a usable GitHub login are skipped instead of failing the whole task push.
 
 ## Comments
 
@@ -640,7 +642,7 @@ A v1 implementation satisfies this spec when:
 3. bootstrap immediately imports open GitHub issues and exports active/inprogress/waiting todu tasks when strategy is `bidirectional`
 4. linked items receive `external_id = owner/repo#number`
 5. title/body/status/priority/labels sync according to the mapping rules and respect the binding strategy
-6. GitHub assignees sync into todu, but not the reverse
+6. GitHub assignees sync bidirectionally when a usable GitHub login is available for outbound assignment; account-id-only identities are skipped with graceful degradation
 7. comments sync bidirectionally for create/edit/delete with strict 1:1 mirrored behavior when the binding strategy includes both directions
 8. status and priority labels normalize deterministically
 9. deletion maps to cancelation instead of hard deletion

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -37,14 +37,14 @@ Documented coverage for major sync behaviors. Each row maps to one or more autom
 
 ## Field Sync
 
-| Behavior                                                    | Type | Status |
-| ----------------------------------------------------------- | ---- | ------ |
-| Push updates linked issue title/body/status/priority/labels | U    | ✅     |
-| Push skips update when GitHub issue is newer                | U    | ✅     |
-| Pull imports GitHub assignees with stable external identity data         | U    | ✅     |
-| Pull imports GitHub comment authors with stable external identity data   | U    | ✅     |
-| Push syncs mapped assignees back to GitHub                               | U    | ✅     |
-| Push skips outbound assignees without usable GitHub logins               | U    | ✅     |
+| Behavior                                                               | Type | Status |
+| ---------------------------------------------------------------------- | ---- | ------ |
+| Push updates linked issue title/body/status/priority/labels            | U    | ✅     |
+| Push skips update when GitHub issue is newer                           | U    | ✅     |
+| Pull imports GitHub assignees with stable external identity data       | U    | ✅     |
+| Pull imports GitHub comment authors with stable external identity data | U    | ✅     |
+| Push syncs mapped assignees back to GitHub                             | U    | ✅     |
+| Push skips outbound assignees without usable GitHub logins             | U    | ✅     |
 
 ## Status and Priority Normalization
 

--- a/docs/TEST_MATRIX.md
+++ b/docs/TEST_MATRIX.md
@@ -41,8 +41,10 @@ Documented coverage for major sync behaviors. Each row maps to one or more autom
 | ----------------------------------------------------------- | ---- | ------ |
 | Push updates linked issue title/body/status/priority/labels | U    | ✅     |
 | Push skips update when GitHub issue is newer                | U    | ✅     |
-| Pull imports GitHub assignees                               | U    | ✅     |
-| Push does not sync assignees back to GitHub                 | U    | ✅     |
+| Pull imports GitHub assignees with stable external identity data         | U    | ✅     |
+| Pull imports GitHub comment authors with stable external identity data   | U    | ✅     |
+| Push syncs mapped assignees back to GitHub                               | U    | ✅     |
+| Push skips outbound assignees without usable GitHub logins               | U    | ✅     |
 
 ## Status and Priority Normalization
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "todu-github-plugin",
       "version": "0.1.0",
       "dependencies": {
-        "@todu/core": "^0.9.0"
+        "@todu/core": "^0.17.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1090,9 +1090,9 @@
       "license": "MIT"
     },
     "node_modules/@todu/core": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.9.0.tgz",
-      "integrity": "sha512-SZUg1MwNn5TCVveTssXy0NLEVUKqXH7VSD07y2I+dFZgCKALWklHeHnN3BMK6itUsWwBiDCYb7NkshmCCmdqvg==",
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@todu/core/-/core-0.17.1.tgz",
+      "integrity": "sha512-xO4QnW7Dd4bTP9ysfqW6kTdH5MC7zh0Rq6UlsON4Dt0bGoxgrd9BE0l5mg1vbqITEwwWpNFGlpHWBAcYkmyPqA==",
       "license": "MIT",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
-    "@todu/core": "^0.9.0"
+    "@todu/core": "^0.17.1"
   }
 }

--- a/src/__tests__/example.test.ts
+++ b/src/__tests__/example.test.ts
@@ -21,6 +21,6 @@ describe("syncProvider registration", () => {
     }
 
     expect(result.value.manifest.name).toBe("github");
-    expect(result.value.manifest.apiVersion).toBe(2);
+    expect(result.value.manifest.apiVersion).toBe(3);
   });
 });

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -7,6 +7,7 @@ import {
   createNoteId,
   createProjectId,
   createTaskId,
+  type ExportedTaskInput,
   type IntegrationBinding,
   type Note,
   type Project,
@@ -40,6 +41,7 @@ import {
   parseGitHubBinding,
   parseGitHubRepositoryTargetRef,
   parseIssueExternalId,
+  pushComments,
   stripAttribution,
   type GitHubComment,
 } from "@/index";
@@ -166,7 +168,7 @@ describe("field normalization", () => {
     ).toEqual(["bug"]);
   });
 
-  it("maps todu task fields to GitHub issue updates without syncing assignees back", () => {
+  it("maps todu task fields to GitHub issue updates including outbound assignees", () => {
     expect(
       createGitHubIssueUpdateFromTask(
         createTaskWithDetail({
@@ -184,6 +186,7 @@ describe("field normalization", () => {
       body: "Markdown body",
       state: "closed",
       labels: ["bug", "status:done", "priority:high"],
+      assignees: ["alice", "bob"],
     });
   });
 });
@@ -246,7 +249,10 @@ describe("createGitHubSyncProvider", () => {
         status: "waiting",
         priority: "high",
         labels: ["bug"],
-        assignees: ["alice", "bob"],
+        assignees: [
+          { externalLogin: "alice", displayName: "alice", raw: "alice" },
+          { externalLogin: "bob", displayName: "bob", raw: "bob" },
+        ],
         sourceUrl: "https://github.com/evcraddock/todu-github-plugin/issues/1",
         createdAt: "2026-03-10T00:00:00.000Z",
         updatedAt: "2026-03-10T00:00:00.000Z",
@@ -259,7 +265,7 @@ describe("createGitHubSyncProvider", () => {
         status: "canceled",
         priority: "low",
         labels: ["enhancement"],
-        assignees: ["octocat"],
+        assignees: [{ externalLogin: "octocat", displayName: "octocat", raw: "octocat" }],
         sourceUrl: "https://github.com/evcraddock/todu-github-plugin/issues/2",
         createdAt: "2026-03-10T00:00:00.000Z",
         updatedAt: "2026-03-10T01:00:00.000Z",
@@ -302,6 +308,7 @@ describe("createGitHubSyncProvider", () => {
         body: "Active body",
         state: "open",
         labels: ["bug", "status:active", "priority:high"],
+        assignees: [],
       },
     ]);
     expect(activeTask.externalId).toBe("evcraddock/todu-github-plugin#1");
@@ -337,6 +344,7 @@ describe("createGitHubSyncProvider", () => {
       status: "done",
       priority: "high",
       labels: ["bug"],
+      assignees: ["caradoc-clanker"],
       updatedAt: "2026-03-10T01:00:00.000Z",
     });
 
@@ -349,7 +357,9 @@ describe("createGitHubSyncProvider", () => {
         body: "New body",
         state: "closed",
         labels: ["bug", "status:done", "priority:high"],
-        assignees: ["alice"],
+        assignees: [
+          { login: "caradoc-clanker", displayName: "caradoc-clanker", raw: "caradoc-clanker" },
+        ],
       },
     ]);
     expect(linkedTask.externalId).toBe("evcraddock/todu-github-plugin#7");
@@ -516,7 +526,7 @@ describe("createGitHubSyncProvider", () => {
     ]);
   });
 
-  it("imports GitHub assignees into todu task metadata and does not sync task assignees back", async () => {
+  it("imports GitHub assignees into v3 task actor refs and syncs mapped local assignees back", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.seedIssues(repositoryTarget(), [
       createIssue({
@@ -535,9 +545,19 @@ describe("createGitHubSyncProvider", () => {
 
     await provider.initialize({ settings: { token: "secret-token" } });
     const pullResult = await provider.pull(createBinding(), createProject());
-    const mappedTask = provider.mapToTask(pullResult.tasks[0], createProject());
 
-    expect(mappedTask.assignees).toEqual(["alice", "bob"]);
+    expect(pullResult.tasks[0]?.assignees).toEqual([
+      {
+        externalLogin: "alice",
+        displayName: "alice",
+        raw: "alice",
+      },
+      {
+        externalLogin: "bob",
+        displayName: "bob",
+        raw: "bob",
+      },
+    ]);
 
     const taskForPush = createTaskWithDetail({
       id: "task-9",
@@ -546,8 +566,137 @@ describe("createGitHubSyncProvider", () => {
       status: "active",
       assignees: ["charlie"],
     });
-    const externalTask = provider.mapFromTask(taskForPush, createProject());
-    expect(externalTask.assignees).toBeUndefined();
+    await provider.push(createBinding(), [taskForPush], createProject());
+    const pushedIssue = issueClient
+      .snapshotIssues(repositoryTarget())
+      .find((issue) => issue.title === "Push task");
+    expect(pushedIssue?.assignees).toEqual([
+      { login: "charlie", displayName: "charlie", raw: "charlie" },
+    ]);
+  });
+
+  it("preserves stable GitHub identity data for assignee and comment-author imports", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 10,
+        title: "Identity-rich issue",
+        body: "Body",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+        assignees: [
+          {
+            id: "101",
+            login: "alice",
+            displayName: "Alice Example",
+            raw: { type: "User", login: "alice" },
+          },
+          {
+            id: "102",
+            login: "dependabot[bot]",
+            displayName: "dependabot[bot]",
+            raw: { type: "Bot", login: "dependabot[bot]" },
+          },
+        ],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 10, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 10,
+        body: "Hello from GitHub",
+        author: {
+          id: "103",
+          login: "release-bot[bot]",
+          displayName: "release-bot[bot]",
+          raw: { type: "Bot", login: "release-bot[bot]" },
+        },
+      }),
+    ]);
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    const pullResult = await provider.pull(createBinding(), createProject());
+
+    expect(pullResult.tasks[0]?.assignees).toEqual([
+      {
+        externalAccountId: "101",
+        externalLogin: "alice",
+        displayName: "Alice Example",
+        raw: { type: "User", login: "alice" },
+      },
+      {
+        externalAccountId: "102",
+        externalLogin: "dependabot[bot]",
+        displayName: "dependabot[bot]",
+        raw: { type: "Bot", login: "dependabot[bot]" },
+      },
+    ]);
+    expect(pullResult.comments).toEqual([
+      expect.objectContaining({
+        externalId: "100",
+        author: {
+          externalAccountId: "103",
+          externalLogin: "release-bot[bot]",
+          displayName: "release-bot[bot]",
+          raw: { type: "Bot", login: "release-bot[bot]" },
+        },
+      }),
+    ]);
+  });
+
+  it("skips outbound assignees that do not have usable GitHub logins", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    await provider.push(
+      createBinding(),
+      [
+        createTaskWithDetail({
+          id: "task-10",
+          title: "Push task with partial mappings",
+          description: "Body",
+          status: "active",
+          assignees: [
+            {
+              externalAccountId: "201",
+              externalLogin: "caradoc-clanker",
+              displayName: "Caradoc Clanker",
+            },
+            {
+              externalAccountId: "202",
+              displayName: "Caradoc Clanker",
+            },
+            {
+              externalAccountId: "203",
+              displayName: "service bot",
+            },
+            {
+              externalAccountId: "204",
+              externalLogin: "dependabot[bot]",
+              displayName: "dependabot[bot]",
+            },
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    const pushedIssue = issueClient
+      .snapshotIssues(repositoryTarget())
+      .find((issue) => issue.title === "Push task with partial mappings");
+    expect(pushedIssue?.assignees).toEqual([
+      { login: "caradoc-clanker", displayName: "caradoc-clanker", raw: "caradoc-clanker" },
+      { login: "dependabot[bot]", displayName: "dependabot[bot]", raw: "dependabot[bot]" },
+    ]);
   });
 
   it("follows the duplicate policy by creating a new issue instead of fuzzy matching by title", async () => {
@@ -839,7 +988,7 @@ describe("comment sync", () => {
       externalId: "100",
       externalTaskId: "evcraddock/todu-github-plugin#1",
       body: "Hello from GitHub",
-      author: "octocat",
+      author: { externalLogin: "octocat", displayName: "octocat", raw: "octocat" },
     });
   });
 
@@ -896,8 +1045,172 @@ describe("comment sync", () => {
       createProject()
     );
 
-    expect(result.commentLinks).toHaveLength(0);
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-imported-1"),
+        externalCommentId: "100",
+        externalTaskId: createTaskId("task-1"),
+      }),
+    ]);
     expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+  });
+
+  it("repairs stale local comment links by trusting the note sync tag", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with stale comment link",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Imported from GitHub",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("external:100"),
+      issueNumber: 1,
+      githubCommentId: 100,
+      lastMirroredAt: "2026-03-10T00:00:00.000Z",
+    });
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-1"),
+      issueNumber: 1,
+      githubCommentId: 200,
+      lastMirroredAt: "2026-03-10T00:00:00.000Z",
+    });
+
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+      loadTaskNotes: async () => [{ id: "note-1", tags: ["sync:externalId:100"] }],
+    });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const result = await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with stale comment link",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Imported from GitHub",
+              author: "octocat",
+              createdAt: "2026-03-10T00:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-1"),
+        externalCommentId: "100",
+        externalTaskId: createTaskId("task-1"),
+      }),
+    ]);
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+    expect(provider.getState().commentLinks).toEqual([
+      {
+        bindingId: binding.id,
+        taskId: createTaskId("task-1"),
+        noteId: createNoteId("note-1"),
+        issueNumber: 1,
+        githubCommentId: 100,
+        lastMirroredAt: "2026-03-10T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("removes stale comment links for missing local notes before pushing", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    const binding = createBinding();
+
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with stale link",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-stale"),
+      issueNumber: 1,
+      githubCommentId: 21,
+      lastMirroredAt: "2026-03-10T00:00:00.000Z",
+    });
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-existing"),
+      issueNumber: 1,
+      githubCommentId: 22,
+      lastMirroredAt: "2026-03-10T00:00:00.000Z",
+    });
+
+    const staleLinks: Array<{ noteId: string; githubCommentId: number }> = [];
+    await pushComments({
+      binding,
+      owner: "evcraddock",
+      repo: "todu-github-plugin",
+      tasks: [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with stale link",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-existing",
+              content: "Existing body",
+              author: "alice",
+              createdAt: "2026-03-10T00:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      issueClient,
+      itemLinkStore: linkStore,
+      commentLinkStore,
+      onStaleLink: ({ commentLink }: { commentLink: { noteId: string; githubCommentId: number } }) => {
+        staleLinks.push({ noteId: String(commentLink.noteId), githubCommentId: commentLink.githubCommentId });
+      },
+    });
+
+    expect(staleLinks).toEqual([{ noteId: "note-stale", githubCommentId: 21 }]);
+    expect(commentLinkStore.getByNoteId(binding.id, createNoteId("note-stale"))).toBeNull();
   });
 
   it("pushes todu comments to GitHub with todu attribution", async () => {
@@ -948,7 +1261,7 @@ describe("comment sync", () => {
 
     const ghComments = issueClient.snapshotComments(repositoryTarget(), 1);
     expect(ghComments).toHaveLength(1);
-    expect(ghComments[0].body).toContain("_Synced from todu comment by @alice on");
+    expect(ghComments[0].body).toContain("_Synced from todu comment by @todu on");
     expect(ghComments[0].body).toContain("Hello from todu");
   });
 
@@ -1082,8 +1395,8 @@ describe("comment sync", () => {
 
     // Comment is retained on GitHub — deletion during sync is disabled
     expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
-    // Comment link is also retained
-    expect(provider.getState().commentLinks).toHaveLength(1);
+    // Stale local link is pruned, but the remote comment is retained.
+    expect(provider.getState().commentLinks).toHaveLength(0);
   });
 
   it("preserves comment link when GitHub comment is deleted (deletion detection is disabled)", async () => {
@@ -1401,7 +1714,7 @@ describe("runtime integration", () => {
     expect(status?.lastErrorSummary).toContain(`retry after ${resetAt.toISOString()}`);
   });
 
-  it("uses a long fallback cooldown when rate-limit metadata is unavailable", async () => {
+  it("uses a long fallback cooldown when primary rate-limit metadata is unavailable", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.listIssues = async () => {
       throw createGitHubApiError({
@@ -1433,6 +1746,41 @@ describe("runtime integration", () => {
     const retryDelayMs = Date.parse(state!.nextRetryAt!) - Date.parse(state!.lastAttemptAt!);
     expect(retryDelayMs).toBe(15 * 60 * 1000);
     expect(state!.lastError).toContain("retry delayed due to GitHub rate limit");
+  });
+
+  it("uses a longer fallback cooldown for secondary rate-limit errors", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.listIssues = async () => {
+      throw createGitHubApiError({
+        status: 403,
+        method: "POST",
+        path: "/repos/evcraddock/todu-github-plugin/issues/1/comments",
+        responseBody:
+          '{"message":"You have exceeded a secondary rate limit and have been temporarily blocked from content creation.","status":"403"}',
+        headers: new Headers(),
+        now: new Date("2026-03-10T00:00:00.000Z"),
+      });
+    };
+
+    const runtimeStore = createInMemoryBindingRuntimeStore();
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore: createInMemoryGitHubItemLinkStore(),
+      runtimeStore,
+      retryConfig: { initialSeconds: 5, maxSeconds: 60 },
+    });
+
+    await provider.initialize({ settings: { token: "secret-token" } });
+    await expect(provider.pull(createBinding(), createProject())).rejects.toThrow(
+      "secondary rate limit"
+    );
+
+    const state = runtimeStore.get(createBinding().id);
+    expect(state).not.toBeNull();
+
+    const retryDelayMs = Date.parse(state!.nextRetryAt!) - Date.parse(state!.lastAttemptAt!);
+    expect(retryDelayMs).toBe(60 * 60 * 1000);
+    expect(state!.lastError).toContain("retry delayed due to GitHub secondary rate limit");
   });
 
   it("skips pull when retry backoff has not elapsed", async () => {
@@ -2018,7 +2366,7 @@ describe("closed bootstrap import", () => {
     expect(result.comments![0]).toMatchObject({
       externalId: "100",
       externalTaskId: "evcraddock/todu-github-plugin#1",
-      author: "octocat",
+      author: { externalLogin: "octocat", displayName: "octocat", raw: "octocat" },
     });
     expect(result.comments![0].body).toContain("Historical comment");
     expect(provider.getState().itemLinks).toHaveLength(1);
@@ -2326,7 +2674,10 @@ describe("incremental sync", () => {
     const lastSuccessAt = runtimeStore.get(createBinding().id)?.lastSuccessAt;
     expect(lastSuccessAt).toBeTruthy();
     expect(capturedOptions).toHaveLength(1);
-    expect(capturedOptions[0].since).toBe(lastSuccessAt);
+    expect(capturedOptions[0].since).toBeTruthy();
+    expect(
+      Date.parse(capturedOptions[0].since ?? "")
+    ).toBeGreaterThanOrEqual(Date.parse(lastSuccessAt ?? ""));
   });
 
   it("pulls all issues after a failed cycle resets since", async () => {
@@ -2458,6 +2809,7 @@ function createProject(): Project {
     name: "todu-github-plugin",
     status: "active",
     priority: "high",
+    authorizedAssigneeActorIds: [],
     createdAt: "2026-03-09T00:00:00.000Z",
     updatedAt: "2026-03-09T00:00:00.000Z",
   };
@@ -2470,20 +2822,41 @@ function createTaskWithDetail(
     status: TaskPushPayload["status"];
     description?: string;
     comments?: Note[];
-  } & Partial<Omit<TaskPushPayload, "id" | "title" | "status" | "description" | "comments">>
-): TaskPushPayload {
+    assignees?: Array<string | { externalLogin?: string; displayName?: string; externalAccountId?: string }>;
+  } & Partial<
+    Omit<
+      TaskPushPayload,
+      "id" | "title" | "status" | "description" | "comments" | "assignees"
+    >
+  >
+): TaskPushPayload & ExportedTaskInput {
+  const localTaskId = createTaskId(overrides.id);
+  const comments = (overrides.comments ?? []).map((comment) => ({
+    ...comment,
+    localNoteId: comment.id,
+    body: comment.content,
+    updatedAt: comment.createdAt,
+  }));
+  const assignees = (overrides.assignees ?? []).map((assignee) =>
+    typeof assignee === "string"
+      ? { externalLogin: assignee, displayName: assignee }
+      : assignee
+  );
+
   return {
-    id: createTaskId(overrides.id),
+    id: localTaskId,
+    localTaskId,
     title: overrides.title,
     status: overrides.status,
     priority: overrides.priority ?? "medium",
     projectId: overrides.projectId ?? createProjectId("project-1"),
     labels: overrides.labels ?? [],
-    assignees: overrides.assignees ?? [],
+    assigneeActorIds: overrides.assigneeActorIds ?? [],
+    assignees: assignees as unknown as string[] & ExportedTaskInput["assignees"],
     externalId: overrides.externalId,
     sourceUrl: overrides.sourceUrl,
     description: overrides.description,
-    comments: overrides.comments ?? [],
+    comments,
     createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-03-10T00:00:00.000Z",
   };
@@ -2495,7 +2868,7 @@ function createIssue(overrides: {
   state: "open" | "closed";
   body?: string;
   labels?: string[];
-  assignees?: string[];
+  assignees?: Array<string | { id?: string; login?: string; displayName?: string; raw?: unknown }>;
   isPullRequest?: boolean;
   updatedAt?: string;
   createdAt?: string;
@@ -2507,7 +2880,11 @@ function createIssue(overrides: {
     body: overrides.body,
     state: overrides.state,
     labels: overrides.labels ?? [],
-    assignees: overrides.assignees ?? [],
+    assignees: (overrides.assignees ?? []).map((assignee) =>
+      typeof assignee === "string"
+        ? { login: assignee, displayName: assignee, raw: assignee }
+        : assignee
+    ),
     sourceUrl: `https://github.com/evcraddock/todu-github-plugin/issues/${overrides.number}`,
     createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
     updatedAt: overrides.updatedAt ?? "2026-03-10T00:00:00.000Z",
@@ -2535,7 +2912,7 @@ function createGitHubComment(overrides: {
   id: number;
   issueNumber: number;
   body: string;
-  author: string;
+  author: string | { id?: string; login?: string; displayName?: string; raw?: unknown };
   createdAt?: string;
   updatedAt?: string;
 }): GitHubComment {
@@ -2543,7 +2920,10 @@ function createGitHubComment(overrides: {
     id: overrides.id,
     issueNumber: overrides.issueNumber,
     body: overrides.body,
-    author: overrides.author,
+    author:
+      typeof overrides.author === "string"
+        ? { login: overrides.author, displayName: overrides.author, raw: overrides.author }
+        : overrides.author,
     sourceUrl: `https://github.com/evcraddock/todu-github-plugin/issues/${overrides.issueNumber}#issuecomment-${overrides.id}`,
     createdAt: overrides.createdAt ?? "2026-03-10T00:00:00.000Z",
     updatedAt: overrides.updatedAt,

--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -1204,8 +1204,15 @@ describe("comment sync", () => {
       issueClient,
       itemLinkStore: linkStore,
       commentLinkStore,
-      onStaleLink: ({ commentLink }: { commentLink: { noteId: string; githubCommentId: number } }) => {
-        staleLinks.push({ noteId: String(commentLink.noteId), githubCommentId: commentLink.githubCommentId });
+      onStaleLink: ({
+        commentLink,
+      }: {
+        commentLink: { noteId: string; githubCommentId: number };
+      }) => {
+        staleLinks.push({
+          noteId: String(commentLink.noteId),
+          githubCommentId: commentLink.githubCommentId,
+        });
       },
     });
 
@@ -2675,9 +2682,9 @@ describe("incremental sync", () => {
     expect(lastSuccessAt).toBeTruthy();
     expect(capturedOptions).toHaveLength(1);
     expect(capturedOptions[0].since).toBeTruthy();
-    expect(
-      Date.parse(capturedOptions[0].since ?? "")
-    ).toBeGreaterThanOrEqual(Date.parse(lastSuccessAt ?? ""));
+    expect(Date.parse(capturedOptions[0].since ?? "")).toBeGreaterThanOrEqual(
+      Date.parse(lastSuccessAt ?? "")
+    );
   });
 
   it("pulls all issues after a failed cycle resets since", async () => {
@@ -2822,12 +2829,11 @@ function createTaskWithDetail(
     status: TaskPushPayload["status"];
     description?: string;
     comments?: Note[];
-    assignees?: Array<string | { externalLogin?: string; displayName?: string; externalAccountId?: string }>;
+    assignees?: Array<
+      string | { externalLogin?: string; displayName?: string; externalAccountId?: string }
+    >;
   } & Partial<
-    Omit<
-      TaskPushPayload,
-      "id" | "title" | "status" | "description" | "comments" | "assignees"
-    >
+    Omit<TaskPushPayload, "id" | "title" | "status" | "description" | "comments" | "assignees">
   >
 ): TaskPushPayload & ExportedTaskInput {
   const localTaskId = createTaskId(overrides.id);
@@ -2838,9 +2844,7 @@ function createTaskWithDetail(
     updatedAt: comment.createdAt,
   }));
   const assignees = (overrides.assignees ?? []).map((assignee) =>
-    typeof assignee === "string"
-      ? { externalLogin: assignee, displayName: assignee }
-      : assignee
+    typeof assignee === "string" ? { externalLogin: assignee, displayName: assignee } : assignee
   );
 
   return {

--- a/src/github-bootstrap.ts
+++ b/src/github-bootstrap.ts
@@ -1,10 +1,10 @@
-import type { ExternalTask, IntegrationBinding, TaskPushPayload } from "@todu/core";
+import type { ExportedTaskInput, ImportedTaskInput, IntegrationBinding } from "@todu/core";
 
 import type { GitHubIssue, GitHubIssueClient } from "@/github-client";
 import {
   createGitHubIssueCreateFromTask,
   createGitHubIssueUpdateFromTask,
-  mapGitHubIssueToExternalTask,
+  mapGitHubIssueToImportedTask,
 } from "@/github-fields";
 import {
   createLinkFromIssue,
@@ -14,20 +14,20 @@ import {
 } from "@/github-links";
 import { parseIssueExternalId } from "@/github-ids";
 
-const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<TaskPushPayload["status"]>([
+const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<ExportedTaskInput["status"]>([
   "active",
   "inprogress",
   "waiting",
 ]);
 
 export interface GitHubBootstrapImportResult {
-  tasks: ExternalTask[];
+  tasks: ImportedTaskInput[];
   createdLinks: GitHubItemLink[];
   touchedIssueNumbers: number[];
 }
 
 export interface GitHubBootstrapTaskUpdate {
-  taskId: TaskPushPayload["id"];
+  taskId: ExportedTaskInput["localTaskId"];
   externalId: string;
   sourceUrl?: string;
 }
@@ -56,7 +56,7 @@ export async function bootstrapGitHubIssuesToTasks(input: {
     input.since ? { since: input.since } : undefined
   );
 
-  const tasks: ExternalTask[] = [];
+  const tasks: ImportedTaskInput[] = [];
   const createdLinks: GitHubItemLink[] = [];
   const touchedIssueNumbers: number[] = [];
 
@@ -83,7 +83,7 @@ export async function bootstrapGitHubIssuesToTasks(input: {
       });
     }
 
-    tasks.push(mapGitHubIssueToExternalTask(issue));
+    tasks.push(mapGitHubIssueToImportedTask(issue));
     touchedIssueNumbers.push(issue.number);
   }
 
@@ -98,7 +98,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
   binding: IntegrationBinding;
   owner: string;
   repo: string;
-  tasks: TaskPushPayload[];
+  tasks: ExportedTaskInput[];
   issueClient: GitHubIssueClient;
   linkStore: GitHubItemLinkStore;
 }): Promise<GitHubBootstrapExportResult> {
@@ -111,7 +111,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
   let skippedLinkedTasks = 0;
 
   for (const task of input.tasks) {
-    const existingLink = input.linkStore.getByTaskId(input.binding.id, task.id);
+    const existingLink = input.linkStore.getByTaskId(input.binding.id, task.localTaskId);
     if (existingLink) {
       task.externalId = existingLink.externalId;
       task.sourceUrl ??= createIssueSourceUrl(input.owner, input.repo, existingLink.issueNumber);
@@ -173,7 +173,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
       );
       const createdLink = createLinkFromTask(
         input.binding,
-        task.id,
+        task.localTaskId,
         input.owner,
         input.repo,
         matchingExternalId.issueNumber,
@@ -221,7 +221,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
 
     const createdLink = createLinkFromTask(
       input.binding,
-      task.id,
+      task.localTaskId,
       input.owner,
       input.repo,
       createdIssue.number,
@@ -232,7 +232,7 @@ export async function bootstrapTasksToGitHubIssues(input: {
     input.linkStore.save(createdLink);
     createdLinks.push(createdLink);
     taskUpdates.push({
-      taskId: task.id,
+      taskId: task.localTaskId,
       externalId: createdLink.externalId,
       sourceUrl: createdIssue.sourceUrl,
     });
@@ -253,7 +253,7 @@ function createIssueSourceUrl(owner: string, repo: string, issueNumber: number):
   return `https://github.com/${owner}/${repo}/issues/${issueNumber}`;
 }
 
-function shouldPushTaskUpdate(task: TaskPushPayload, issue: GitHubIssue | null): boolean {
+function shouldPushTaskUpdate(task: ExportedTaskInput, issue: GitHubIssue | null): boolean {
   if (!issue) {
     return true;
   }
@@ -262,7 +262,7 @@ function shouldPushTaskUpdate(task: TaskPushPayload, issue: GitHubIssue | null):
 }
 
 function shouldPushTaskUpdateFromMirroredAt(
-  task: TaskPushPayload,
+  task: ExportedTaskInput,
   lastMirroredAt: string | undefined
 ): boolean {
   if (!lastMirroredAt) {
@@ -280,7 +280,7 @@ function shouldPushTaskUpdateFromMirroredAt(
 }
 
 function getMatchingExternalId(
-  task: TaskPushPayload,
+  task: ExportedTaskInput,
   owner: string,
   repo: string
 ): { issueNumber: number } | null {

--- a/src/github-client.ts
+++ b/src/github-client.ts
@@ -1,5 +1,12 @@
 import type { GitHubRepositoryTarget } from "@/github-binding";
 
+export interface GitHubUserRef {
+  id?: string;
+  login?: string;
+  displayName?: string;
+  raw?: unknown;
+}
+
 export interface GitHubIssue {
   number: number;
   externalId: string;
@@ -7,7 +14,7 @@ export interface GitHubIssue {
   body?: string;
   state: "open" | "closed";
   labels: string[];
-  assignees: string[];
+  assignees: GitHubUserRef[];
   sourceUrl?: string;
   createdAt?: string;
   updatedAt?: string;
@@ -18,7 +25,7 @@ export interface GitHubComment {
   id: number;
   issueNumber: number;
   body: string;
-  author: string;
+  author: GitHubUserRef;
   sourceUrl?: string;
   createdAt: string;
   updatedAt?: string;
@@ -29,6 +36,7 @@ export interface CreateGitHubIssueInput {
   body?: string;
   state?: GitHubIssue["state"];
   labels?: string[];
+  assignees?: string[];
 }
 
 export interface UpdateGitHubIssueInput {
@@ -36,6 +44,7 @@ export interface UpdateGitHubIssueInput {
   body?: string;
   state?: GitHubIssue["state"];
   labels?: string[];
+  assignees?: string[];
 }
 
 export interface ListIssuesOptions {
@@ -115,13 +124,21 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
     commentsByIssue.set(getCommentKey(target, issueNumber), comments);
   };
 
+  const cloneUserRef = (user: GitHubUserRef): GitHubUserRef => ({ ...user });
+
+  const normalizeSeedUserRef = (user: GitHubUserRef | string): GitHubUserRef =>
+    typeof user === "string" ? { login: user, displayName: user, raw: user } : cloneUserRef(user);
+
   const cloneIssue = (issue: GitHubIssue): GitHubIssue => ({
     ...issue,
     labels: [...issue.labels],
-    assignees: [...issue.assignees],
+    assignees: issue.assignees.map(cloneUserRef),
   });
 
-  const cloneComment = (comment: GitHubComment): GitHubComment => ({ ...comment });
+  const cloneComment = (comment: GitHubComment): GitHubComment => ({
+    ...comment,
+    author: cloneUserRef(comment.author),
+  });
 
   const createIssueSourceUrl = (target: GitHubRepositoryTarget, issueNumber: number): string =>
     `https://github.com/${target.owner}/${target.repo}/issues/${issueNumber}`;
@@ -160,7 +177,7 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
           cloneIssue({
             ...issue,
             externalId: issue.externalId ?? `${target.owner}/${target.repo}#${issue.number}`,
-            assignees: [...(issue.assignees ?? [])],
+            assignees: (issue.assignees ?? []).map(normalizeSeedUserRef),
           })
         )
       );
@@ -176,6 +193,7 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
           ...comment,
           id,
           issueNumber,
+          author: normalizeSeedUserRef(comment.author),
           sourceUrl: comment.sourceUrl ?? createCommentSourceUrl(target, issueNumber, id),
         });
       });
@@ -220,7 +238,7 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
         body: input.body,
         state: input.state ?? "open",
         labels: [...(input.labels ?? [])],
-        assignees: [],
+        assignees: (input.assignees ?? []).map((assignee) => normalizeSeedUserRef(assignee)),
         sourceUrl: createIssueSourceUrl(target, nextIssueNumber),
         createdAt: timestamp,
         updatedAt: timestamp,
@@ -243,6 +261,9 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
         body: input.body ?? existingIssue.body,
         state: input.state ?? existingIssue.state,
         labels: input.labels ? [...input.labels] : [...existingIssue.labels],
+        assignees: input.assignees
+          ? input.assignees.map((assignee) => normalizeSeedUserRef(assignee))
+          : [...existingIssue.assignees],
         updatedAt: new Date().toISOString(),
       };
 
@@ -271,7 +292,10 @@ export function createInMemoryGitHubIssueClient(): InMemoryGitHubIssueClient {
         id: commentId,
         issueNumber,
         body,
-        author: "github-token-user",
+        author: {
+          login: "github-token-user",
+          displayName: "github-token-user",
+        },
         sourceUrl: createCommentSourceUrl(target, issueNumber, commentId),
         createdAt: timestamp,
         updatedAt: timestamp,

--- a/src/github-comment-links.ts
+++ b/src/github-comment-links.ts
@@ -80,6 +80,18 @@ export function createInMemoryGitHubCommentLinkStore(): GitHubCommentLinkStore {
       return [...allLinks.values()];
     },
     save(link): void {
+      const existingByNote = links.get(getNoteKey(link.bindingId, link.noteId));
+      if (existingByNote) {
+        links.delete(getGitHubKey(link.bindingId, existingByNote.githubCommentId));
+      }
+
+      const existingByGitHubComment = links.get(
+        getGitHubKey(link.bindingId, link.githubCommentId)
+      );
+      if (existingByGitHubComment) {
+        links.delete(getNoteKey(link.bindingId, existingByGitHubComment.noteId));
+      }
+
       links.set(getNoteKey(link.bindingId, link.noteId), link);
       links.set(getGitHubKey(link.bindingId, link.githubCommentId), link);
     },

--- a/src/github-comment-links.ts
+++ b/src/github-comment-links.ts
@@ -85,9 +85,7 @@ export function createInMemoryGitHubCommentLinkStore(): GitHubCommentLinkStore {
         links.delete(getGitHubKey(link.bindingId, existingByNote.githubCommentId));
       }
 
-      const existingByGitHubComment = links.get(
-        getGitHubKey(link.bindingId, link.githubCommentId)
-      );
+      const existingByGitHubComment = links.get(getGitHubKey(link.bindingId, link.githubCommentId));
       if (existingByGitHubComment) {
         links.delete(getNoteKey(link.bindingId, existingByGitHubComment.noteId));
       }

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -184,7 +184,10 @@ function resolveCommentLinkForPush(input: {
   comment: ExportedCommentInput;
   commentLinkStore: GitHubCommentLinkStore;
 }): GitHubCommentLink | null {
-  const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, input.comment.localNoteId);
+  const existingLink = input.commentLinkStore.getByNoteId(
+    input.binding.id,
+    input.comment.localNoteId
+  );
   const syncExternalCommentId = getSyncExternalCommentIdFromTags(
     (input.comment as { tags?: unknown }).tags
   );
@@ -237,7 +240,10 @@ export async function pushComments(input: {
   loadTaskNotes?: (
     taskId: ExportedTaskInput["localTaskId"]
   ) => Promise<Array<{ id: string; tags: string[] }>>;
-  onStaleLink?: (context: { itemLink: GitHubItemLink; commentLink: GitHubCommentLink }) => void | Promise<void>;
+  onStaleLink?: (context: {
+    itemLink: GitHubItemLink;
+    commentLink: GitHubCommentLink;
+  }) => void | Promise<void>;
 }): Promise<PushCommentsResult> {
   const commentLinks: SyncProviderPushCommentLink[] = [];
   const createdComments: GitHubComment[] = [];
@@ -294,7 +300,12 @@ export async function pushComments(input: {
           updatedComments
         );
         commentLinks.push(
-          createPushCommentLink(comment.localNoteId, existingLink.githubCommentId, externalTaskId, updated)
+          createPushCommentLink(
+            comment.localNoteId,
+            existingLink.githubCommentId,
+            externalTaskId,
+            updated
+          )
         );
       } else {
         const created = await createGitHubCommentFromExport(

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -1,24 +1,37 @@
 import type {
-  ExternalComment,
+  ExportedCommentInput,
+  ExportedTaskInput,
+  ImportedCommentInput,
   IntegrationBinding,
   Note,
   NoteId,
   SyncProviderPushCommentLink,
-  TaskPushPayload,
 } from "@todu/core";
 
 import type { GitHubComment, GitHubIssueClient } from "@/github-client";
 import type { GitHubCommentLink, GitHubCommentLinkStore } from "@/github-comment-links";
-import type { GitHubItemLink, GitHubItemLinkStore } from "@/github-links";
+import { mapGitHubUserToExternalActorRef } from "@/github-fields";
 import { formatIssueExternalId } from "@/github-ids";
+import type { GitHubItemLink, GitHubItemLinkStore } from "@/github-links";
 
 const GITHUB_ATTRIBUTION_PREFIX = "_Synced from GitHub comment by @";
 const TODU_ATTRIBUTION_PREFIX = "_Synced from todu comment by @";
 const ATTRIBUTION_SUFFIX_PATTERN = / on \d{4}-\d{2}-\d{2}T[\d:.]+Z_$/;
 const SYNC_EXTERNAL_ID_TAG_PREFIX = "sync:externalId:";
 
-export function formatGitHubAttribution(author: string, timestamp: string): string {
-  return `_Synced from GitHub comment by @${author} on ${timestamp}_`;
+function getDisplayAuthor(author: { login?: string; displayName?: string } | string): string {
+  if (typeof author === "string") {
+    return author;
+  }
+
+  return author.login ?? author.displayName ?? "unknown";
+}
+
+export function formatGitHubAttribution(
+  author: { login?: string; displayName?: string } | string,
+  timestamp: string
+): string {
+  return `_Synced from GitHub comment by @${getDisplayAuthor(author)} on ${timestamp}_`;
 }
 
 export function formatToduAttribution(author: string, timestamp: string): string {
@@ -55,12 +68,31 @@ export function hasGitHubAttribution(body: string): boolean {
   );
 }
 
+function getSyncExternalCommentIdFromTags(tags: unknown): number | null {
+  if (!Array.isArray(tags)) {
+    return null;
+  }
+
+  for (const tag of tags) {
+    if (typeof tag !== "string" || !tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX)) {
+      continue;
+    }
+
+    const externalId = Number.parseInt(tag.slice(SYNC_EXTERNAL_ID_TAG_PREFIX.length), 10);
+    if (Number.isInteger(externalId) && externalId > 0) {
+      return externalId;
+    }
+  }
+
+  return null;
+}
+
 function hasImportedGitHubSyncTag(note: Note): boolean {
-  return note.tags.some((tag) => tag.startsWith(SYNC_EXTERNAL_ID_TAG_PREFIX));
+  return getSyncExternalCommentIdFromTags(note.tags) !== null;
 }
 
 export interface PullCommentsResult {
-  comments: ExternalComment[];
+  comments: ImportedCommentInput[];
   createdLinks: GitHubCommentLink[];
 }
 
@@ -74,7 +106,7 @@ export async function pullComments(input: {
   issueNumbers?: readonly number[];
   since?: string;
 }): Promise<PullCommentsResult> {
-  const comments: ExternalComment[] = [];
+  const comments: ImportedCommentInput[] = [];
   const createdLinks: GitHubCommentLink[] = [];
 
   const issueNumbers = input.issueNumbers ? new Set(input.issueNumbers) : null;
@@ -102,7 +134,7 @@ export async function pullComments(input: {
         externalId: String(ghComment.id),
         externalTaskId,
         body,
-        author: ghComment.author,
+        author: mapGitHubUserToExternalActorRef(ghComment.author),
         createdAt: ghComment.createdAt,
         updatedAt: ghComment.updatedAt,
         raw: ghComment,
@@ -145,54 +177,136 @@ export interface PushCommentsResult {
   updatedComments: GitHubComment[];
 }
 
+function resolveCommentLinkForPush(input: {
+  binding: IntegrationBinding;
+  taskId: ExportedTaskInput["localTaskId"];
+  itemLink: GitHubItemLink;
+  comment: ExportedCommentInput;
+  commentLinkStore: GitHubCommentLinkStore;
+}): GitHubCommentLink | null {
+  const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, input.comment.localNoteId);
+  const syncExternalCommentId = getSyncExternalCommentIdFromTags(
+    (input.comment as { tags?: unknown }).tags
+  );
+
+  if (syncExternalCommentId === null) {
+    return existingLink;
+  }
+
+  const canonicalLink = input.commentLinkStore.getByGitHubCommentId(
+    input.binding.id,
+    syncExternalCommentId
+  );
+  const reconciledLink: GitHubCommentLink = {
+    bindingId: input.binding.id,
+    taskId: input.taskId,
+    noteId: input.comment.localNoteId,
+    issueNumber: input.itemLink.issueNumber,
+    githubCommentId: syncExternalCommentId,
+    lastMirroredAt:
+      canonicalLink?.lastMirroredAt ??
+      existingLink?.lastMirroredAt ??
+      input.comment.updatedAt ??
+      input.comment.createdAt,
+  };
+
+  if (existingLink && existingLink.githubCommentId !== syncExternalCommentId) {
+    input.commentLinkStore.remove(input.binding.id, input.comment.localNoteId);
+  }
+
+  if (
+    canonicalLink?.noteId !== input.comment.localNoteId ||
+    canonicalLink?.taskId !== input.taskId ||
+    canonicalLink?.issueNumber !== input.itemLink.issueNumber ||
+    existingLink?.githubCommentId !== syncExternalCommentId
+  ) {
+    input.commentLinkStore.save(reconciledLink);
+  }
+
+  return canonicalLink?.noteId === input.comment.localNoteId ? canonicalLink : reconciledLink;
+}
+
 export async function pushComments(input: {
   binding: IntegrationBinding;
   owner: string;
   repo: string;
-  tasks: TaskPushPayload[];
+  tasks: ExportedTaskInput[];
   issueClient: GitHubIssueClient;
   itemLinkStore: GitHubItemLinkStore;
   commentLinkStore: GitHubCommentLinkStore;
+  loadTaskNotes?: (
+    taskId: ExportedTaskInput["localTaskId"]
+  ) => Promise<Array<{ id: string; tags: string[] }>>;
+  onStaleLink?: (context: { itemLink: GitHubItemLink; commentLink: GitHubCommentLink }) => void | Promise<void>;
 }): Promise<PushCommentsResult> {
   const commentLinks: SyncProviderPushCommentLink[] = [];
   const createdComments: GitHubComment[] = [];
   const updatedComments: GitHubComment[] = [];
 
   for (const task of input.tasks) {
-    const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.id);
+    const itemLink = input.itemLinkStore.getByTaskId(input.binding.id, task.localTaskId);
     if (!itemLink) {
       continue;
     }
 
-    const localTaskId = task.id;
+    const externalTaskId = String(task.localTaskId);
+    const taskNotes = input.loadTaskNotes ? await input.loadTaskNotes(task.localTaskId) : [];
+    const noteTagsById = new Map(taskNotes.map((note) => [String(note.id), note.tags]));
+    const currentNoteIds = new Set(task.comments.map((comment) => String(comment.localNoteId)));
 
-    for (const note of task.comments) {
-      const existingLink = input.commentLinkStore.getByNoteId(input.binding.id, note.id);
+    for (const existingCommentLink of input.commentLinkStore.listByIssue(
+      input.binding.id,
+      itemLink.issueNumber
+    )) {
+      if (currentNoteIds.has(String(existingCommentLink.noteId))) {
+        continue;
+      }
 
-      if (!existingLink && (hasGitHubAttribution(note.content) || hasImportedGitHubSyncTag(note))) {
+      input.commentLinkStore.remove(input.binding.id, existingCommentLink.noteId);
+      await input.onStaleLink?.({ itemLink, commentLink: existingCommentLink });
+    }
+
+    for (const comment of task.comments) {
+      const commentWithTags = {
+        ...comment,
+        tags: noteTagsById.get(String(comment.localNoteId)) ?? (comment as { tags?: unknown }).tags,
+      };
+      const existingLink = resolveCommentLinkForPush({
+        binding: input.binding,
+        taskId: task.localTaskId,
+        itemLink,
+        comment: commentWithTags,
+        commentLinkStore: input.commentLinkStore,
+      });
+
+      const hasImportedSyncTag =
+        getSyncExternalCommentIdFromTags((commentWithTags as { tags?: unknown }).tags) !== null;
+
+      if (!existingLink && (hasGitHubAttribution(comment.body) || hasImportedSyncTag)) {
         continue;
       }
 
       if (existingLink) {
         const updated = await updateGitHubCommentIfNeeded(
           input,
-          note,
+          comment,
           existingLink,
-          itemLink,
           updatedComments
         );
         commentLinks.push(
-          createPushCommentLink(note.id, existingLink.githubCommentId, localTaskId, updated)
+          createPushCommentLink(comment.localNoteId, existingLink.githubCommentId, externalTaskId, updated)
         );
       } else {
-        const created = await createGitHubCommentFromNote(
+        const created = await createGitHubCommentFromExport(
           input,
-          note,
+          comment,
           task,
           itemLink,
           createdComments
         );
-        commentLinks.push(createPushCommentLink(note.id, created.id, localTaskId, created));
+        commentLinks.push(
+          createPushCommentLink(comment.localNoteId, created.id, externalTaskId, created)
+        );
       }
     }
   }
@@ -208,25 +322,24 @@ async function updateGitHubCommentIfNeeded(
     issueClient: GitHubIssueClient;
     commentLinkStore: GitHubCommentLinkStore;
   },
-  note: Note,
+  comment: ExportedCommentInput,
   existingLink: GitHubCommentLink,
-  _itemLink: GitHubItemLink,
   updatedComments: GitHubComment[]
 ): Promise<GitHubComment | null> {
-  const noteUpdatedAt = Date.parse(note.createdAt);
+  const commentUpdatedAt = Date.parse(comment.updatedAt ?? comment.createdAt);
   const lastMirroredAt = Date.parse(existingLink.lastMirroredAt);
 
   if (
-    !Number.isNaN(noteUpdatedAt) &&
+    !Number.isNaN(commentUpdatedAt) &&
     !Number.isNaN(lastMirroredAt) &&
-    noteUpdatedAt <= lastMirroredAt
+    commentUpdatedAt <= lastMirroredAt
   ) {
     return null;
   }
 
   const attributedBody = formatAttributedBody(
-    formatToduAttribution(note.author, note.createdAt),
-    note.content
+    formatToduAttribution("todu", comment.createdAt),
+    comment.body
   );
 
   const updated = await input.issueClient.updateComment(
@@ -239,13 +352,13 @@ async function updateGitHubCommentIfNeeded(
 
   input.commentLinkStore.save({
     ...existingLink,
-    lastMirroredAt: note.createdAt,
+    lastMirroredAt: comment.updatedAt ?? comment.createdAt,
   });
 
   return updated;
 }
 
-async function createGitHubCommentFromNote(
+async function createGitHubCommentFromExport(
   input: {
     binding: IntegrationBinding;
     owner: string;
@@ -253,14 +366,14 @@ async function createGitHubCommentFromNote(
     issueClient: GitHubIssueClient;
     commentLinkStore: GitHubCommentLinkStore;
   },
-  note: Note,
-  task: TaskPushPayload,
+  comment: ExportedCommentInput,
+  task: ExportedTaskInput,
   itemLink: GitHubItemLink,
   createdComments: GitHubComment[]
 ): Promise<GitHubComment> {
   const attributedBody = formatAttributedBody(
-    formatToduAttribution(note.author, note.createdAt),
-    note.content
+    formatToduAttribution("todu", comment.createdAt),
+    comment.body
   );
 
   const created = await input.issueClient.createComment(
@@ -273,11 +386,11 @@ async function createGitHubCommentFromNote(
 
   const newLink: GitHubCommentLink = {
     bindingId: input.binding.id,
-    taskId: task.id,
-    noteId: note.id,
+    taskId: task.localTaskId,
+    noteId: comment.localNoteId,
     issueNumber: itemLink.issueNumber,
     githubCommentId: created.id,
-    lastMirroredAt: note.createdAt,
+    lastMirroredAt: comment.updatedAt ?? comment.createdAt,
   };
 
   input.commentLinkStore.save(newLink);
@@ -299,4 +412,8 @@ function createPushCommentLink(
     createdAt: comment?.createdAt,
     updatedAt: comment?.updatedAt,
   };
+}
+
+export function shouldSkipImportedGitHubNote(note: Note): boolean {
+  return hasGitHubAttribution(note.content) || hasImportedGitHubSyncTag(note);
 }

--- a/src/github-fields.ts
+++ b/src/github-fields.ts
@@ -1,6 +1,17 @@
-import type { ExternalTask, Task, TaskStatus, TaskWithDetail } from "@todu/core";
+import type {
+  ExportedTaskInput,
+  ExternalActorRef,
+  ImportedTaskInput,
+  Task,
+  TaskStatus,
+} from "@todu/core";
 
-import type { CreateGitHubIssueInput, GitHubIssue, UpdateGitHubIssueInput } from "@/github-client";
+import type {
+  CreateGitHubIssueInput,
+  GitHubIssue,
+  GitHubUserRef,
+  UpdateGitHubIssueInput,
+} from "@/github-client";
 
 const OPEN_STATUS_PRECEDENCE: TaskStatus[] = ["active", "inprogress", "waiting"];
 const CLOSED_STATUS_PRECEDENCE: TaskStatus[] = ["done", "canceled"];
@@ -26,10 +37,33 @@ export interface GitHubFieldMapping {
   status: TaskStatus;
   priority: Task["priority"];
   labels: string[];
-  assignees: string[];
+  assignees: ExternalActorRef[];
 }
 
-export function mapGitHubIssueToExternalTask(issue: GitHubIssue): ExternalTask {
+export function createGitHubAssigneesFromTask(task: ExportedTaskInput): string[] {
+  return task.assignees.flatMap((assignee) => {
+    if (assignee.externalLogin && assignee.externalLogin.trim().length > 0) {
+      return [assignee.externalLogin];
+    }
+
+    if (assignee.displayName && /^[A-Za-z0-9-]+$/.test(assignee.displayName)) {
+      return [assignee.displayName];
+    }
+
+    return [];
+  });
+}
+
+export function mapGitHubUserToExternalActorRef(user: GitHubUserRef): ExternalActorRef {
+  return {
+    ...(user.id !== undefined ? { externalAccountId: user.id } : {}),
+    ...(user.login !== undefined ? { externalLogin: user.login } : {}),
+    ...(user.displayName !== undefined ? { displayName: user.displayName } : {}),
+    ...(user.raw !== undefined ? { raw: user.raw } : {}),
+  };
+}
+
+export function mapGitHubIssueToImportedTask(issue: GitHubIssue): ImportedTaskInput {
   const normalizedStatus = normalizeGitHubIssueStatus(issue.state, issue.labels);
   const normalizedPriority = normalizeGitHubIssuePriority(issue.labels);
 
@@ -40,7 +74,7 @@ export function mapGitHubIssueToExternalTask(issue: GitHubIssue): ExternalTask {
     status: normalizedStatus.status,
     priority: normalizedPriority.priority,
     labels: getNormalGitHubLabels(issue.labels),
-    assignees: [...issue.assignees],
+    assignees: issue.assignees.map(mapGitHubUserToExternalActorRef),
     sourceUrl: issue.sourceUrl,
     createdAt: issue.createdAt,
     updatedAt: issue.updatedAt,
@@ -48,7 +82,7 @@ export function mapGitHubIssueToExternalTask(issue: GitHubIssue): ExternalTask {
   };
 }
 
-export function createGitHubIssueCreateFromTask(task: TaskWithDetail): CreateGitHubIssueInput {
+export function createGitHubIssueCreateFromTask(task: ExportedTaskInput): CreateGitHubIssueInput {
   const normalizedStatus = createGitHubStatusFromTask(task.status);
   const normalizedPriority = createGitHubPriorityFromTask(task.priority);
 
@@ -61,10 +95,11 @@ export function createGitHubIssueCreateFromTask(task: TaskWithDetail): CreateGit
       normalizedStatus.statusLabel,
       normalizedPriority.priorityLabel
     ),
+    assignees: createGitHubAssigneesFromTask(task),
   };
 }
 
-export function createGitHubIssueUpdateFromTask(task: TaskWithDetail): UpdateGitHubIssueInput {
+export function createGitHubIssueUpdateFromTask(task: ExportedTaskInput): UpdateGitHubIssueInput {
   return createGitHubIssueCreateFromTask(task);
 }
 

--- a/src/github-http-client.ts
+++ b/src/github-http-client.ts
@@ -4,9 +4,16 @@ import type {
   GitHubComment,
   GitHubIssue,
   GitHubIssueClient,
+  GitHubUserRef,
   ListIssuesOptions,
   UpdateGitHubIssueInput,
 } from "@/github-client";
+
+interface GitHubApiUser {
+  id?: number;
+  login?: string;
+  name?: string | null;
+}
 
 interface GitHubApiIssue {
   number: number;
@@ -14,7 +21,7 @@ interface GitHubApiIssue {
   body?: string | null;
   state: "open" | "closed";
   labels: Array<{ name: string } | string>;
-  assignees?: Array<{ login: string }>;
+  assignees?: GitHubApiUser[];
   html_url: string;
   created_at: string;
   updated_at: string;
@@ -24,7 +31,7 @@ interface GitHubApiIssue {
 interface GitHubApiComment {
   id: number;
   body: string;
-  user?: { login: string } | null;
+  user?: GitHubApiUser | null;
   html_url: string;
   created_at: string;
   updated_at: string;
@@ -36,6 +43,7 @@ export class GitHubApiError extends Error {
   readonly path: string;
   readonly responseBody: string;
   readonly isRateLimitError: boolean;
+  readonly isSecondaryRateLimitError: boolean;
   readonly retryAt: string | null;
 
   constructor(input: {
@@ -44,6 +52,7 @@ export class GitHubApiError extends Error {
     path: string;
     responseBody: string;
     isRateLimitError: boolean;
+    isSecondaryRateLimitError: boolean;
     retryAt: string | null;
   }) {
     super(`GitHub API ${input.method} ${input.path} failed: ${input.status} ${input.responseBody}`);
@@ -53,6 +62,7 @@ export class GitHubApiError extends Error {
     this.path = input.path;
     this.responseBody = input.responseBody;
     this.isRateLimitError = input.isRateLimitError;
+    this.isSecondaryRateLimitError = input.isSecondaryRateLimitError;
     this.retryAt = input.retryAt;
   }
 }
@@ -77,6 +87,15 @@ function parseRetryAtFromHeaders(headers: Headers, now: Date = new Date()): stri
   return null;
 }
 
+function isSecondaryRateLimitResponse(status: number, responseBody: string): boolean {
+  if (status !== 403) {
+    return false;
+  }
+
+  const normalizedBody = responseBody.toLowerCase();
+  return normalizedBody.includes("secondary rate limit");
+}
+
 function isRateLimitResponse(status: number, headers: Headers, responseBody: string): boolean {
   if (status === 429) {
     return true;
@@ -84,6 +103,10 @@ function isRateLimitResponse(status: number, headers: Headers, responseBody: str
 
   if (status !== 403) {
     return false;
+  }
+
+  if (isSecondaryRateLimitResponse(status, responseBody)) {
+    return true;
   }
 
   const remainingHeader = headers.get("x-ratelimit-remaining");
@@ -103,6 +126,7 @@ export function createGitHubApiError(input: {
   now?: Date;
 }): GitHubApiError {
   const now = input.now ?? new Date();
+  const secondaryRateLimitError = isSecondaryRateLimitResponse(input.status, input.responseBody);
   const rateLimitError = isRateLimitResponse(input.status, input.headers, input.responseBody);
 
   return new GitHubApiError({
@@ -111,6 +135,7 @@ export function createGitHubApiError(input: {
     path: input.path,
     responseBody: input.responseBody,
     isRateLimitError: rateLimitError,
+    isSecondaryRateLimitError: secondaryRateLimitError,
     retryAt: rateLimitError ? parseRetryAtFromHeaders(input.headers, now) : null,
   });
 }
@@ -123,8 +148,17 @@ function normalizeLabels(labels: GitHubApiIssue["labels"]): string[] {
   return labels.map((label) => (typeof label === "string" ? label : label.name));
 }
 
-function normalizeAssignees(assignees?: Array<{ login: string }>): string[] {
-  return (assignees ?? []).map((a) => a.login);
+function normalizeUserRef(user: GitHubApiUser | undefined | null, raw: unknown): GitHubUserRef {
+  return {
+    ...(user?.id !== undefined ? { id: String(user.id) } : {}),
+    ...(user?.login !== undefined ? { login: user.login } : {}),
+    ...((user?.name ?? undefined) !== undefined ? { displayName: user?.name ?? undefined } : {}),
+    raw,
+  };
+}
+
+function normalizeAssignees(assignees?: GitHubApiUser[]): GitHubUserRef[] {
+  return (assignees ?? []).map((assignee) => normalizeUserRef(assignee, assignee));
 }
 
 function mapApiIssue(target: GitHubRepositoryTarget, raw: GitHubApiIssue): GitHubIssue {
@@ -152,7 +186,7 @@ function mapApiComment(
     id: raw.id,
     issueNumber,
     body: raw.body,
-    author: raw.user?.login ?? "unknown",
+    author: normalizeUserRef(raw.user, raw.user ?? { login: "unknown" }),
     sourceUrl: raw.html_url,
     createdAt: raw.created_at,
     updatedAt: raw.updated_at,
@@ -257,6 +291,7 @@ export function createHttpGitHubIssueClient(token: string): GitHubIssueClient {
           title: input.title,
           body: input.body,
           labels: input.labels,
+          assignees: input.assignees,
         }
       );
 
@@ -276,6 +311,7 @@ export function createHttpGitHubIssueClient(token: string): GitHubIssueClient {
           ...(input.body != null ? { body: input.body } : {}),
           ...(input.state != null ? { state: input.state } : {}),
           ...(input.labels != null ? { labels: input.labels } : {}),
+          ...(input.assignees != null ? { assignees: input.assignees } : {}),
         }
       );
 

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -1,18 +1,18 @@
+import { execFile } from "node:child_process";
 import path from "node:path";
+import { promisify } from "node:util";
 
-import {
-  SYNC_PROVIDER_API_VERSION,
-  type ExternalTask,
-  type IntegrationBinding,
-  type Project,
-  type SyncProvider,
-  type SyncProviderConfig,
-  type SyncProviderPullResult,
-  type SyncProviderPushResult,
-  type SyncProviderRegistration,
-  type Task,
-  type TaskPushPayload,
+import type {
+  ExportedTaskInput,
+  IntegrationBinding,
+  Project,
+  SyncProviderConfig,
+  SyncProviderPullResultV3,
+  SyncProviderPushResult,
+  SyncProviderRegistration,
+  SyncProviderV3,
 } from "@todu/core";
+import { SYNC_PROVIDER_API_VERSION } from "@todu/core";
 
 import {
   createBindingStatus,
@@ -33,16 +33,15 @@ import {
   type GitHubBootstrapImportResult,
 } from "@/github-bootstrap";
 import { createInMemoryGitHubIssueClient, type GitHubIssueClient } from "@/github-client";
-import { createHttpGitHubIssueClient, isGitHubRateLimitError } from "@/github-http-client";
+import { pullComments, pushComments } from "@/github-comments";
 import {
   createFileGitHubCommentLinkStore,
   createInMemoryGitHubCommentLinkStore,
   type GitHubCommentLink,
   type GitHubCommentLinkStore,
 } from "@/github-comment-links";
-import { pullComments, pushComments } from "@/github-comments";
 import { loadGitHubProviderSettings, type GitHubProviderSettings } from "@/github-config";
-import { createImportedTaskId } from "@/github-ids";
+import { createHttpGitHubIssueClient, isGitHubRateLimitError } from "@/github-http-client";
 import {
   createFileGitHubItemLinkStore,
   createInMemoryGitHubItemLinkStore,
@@ -72,12 +71,10 @@ import {
 
 export const GITHUB_PROVIDER_VERSION = "0.1.0";
 
-const DEFAULT_TIMESTAMP = new Date(0).toISOString();
-const OPEN_TASK_STATUSES = new Set(["active", "inprogress", "waiting"]);
-const TASK_PRIORITIES = new Set(["low", "medium", "high"]);
 const DEFAULT_LOOP_PREVENTION_MAX_AGE_MS = 10 * 60 * 1000;
 const IMPORT_CLOSED_ON_BOOTSTRAP_OPTION = "importClosedOnBootstrap";
 const RATE_LIMIT_FALLBACK_DELAY_SECONDS = 15 * 60;
+const SECONDARY_RATE_LIMIT_FALLBACK_DELAY_SECONDS = 60 * 60;
 const COMMENT_LINK_STORAGE_FILE = "comment-links.json";
 const RUNTIME_STORAGE_FILE = "runtime-state.json";
 
@@ -91,7 +88,7 @@ export interface GitHubProviderState {
   bindingStatuses: Map<IntegrationBinding["id"], BindingStatus>;
 }
 
-export interface GitHubSyncProvider extends SyncProvider {
+export interface GitHubSyncProvider extends SyncProviderV3 {
   getState(): GitHubProviderState;
 }
 
@@ -103,6 +100,9 @@ export interface CreateGitHubSyncProviderOptions {
   loopPreventionStore?: LoopPreventionStore;
   logger?: GitHubSyncLogger;
   retryConfig?: RetryConfig;
+  loadTaskNotes?: (
+    taskId: ExportedTaskInput["localTaskId"]
+  ) => Promise<Array<{ id: string; tags: string[] }>>;
 }
 
 function isImportClosedOnBootstrapEnabled(binding: IntegrationBinding): boolean {
@@ -123,6 +123,10 @@ function getRetryOverrideForError(
     }
   }
 
+  if (error.isSecondaryRateLimitError) {
+    return { delaySeconds: SECONDARY_RATE_LIMIT_FALLBACK_DELAY_SECONDS };
+  }
+
   return { delaySeconds: RATE_LIMIT_FALLBACK_DELAY_SECONDS };
 }
 
@@ -131,6 +135,10 @@ function getErrorSummary(error: unknown): string {
 
   if (isGitHubRateLimitError(error) && error.retryAt != null) {
     return `${message} (retry after ${error.retryAt})`;
+  }
+
+  if (isGitHubRateLimitError(error) && error.isSecondaryRateLimitError) {
+    return `${message} (retry delayed due to GitHub secondary rate limit)`;
   }
 
   if (isGitHubRateLimitError(error)) {
@@ -142,6 +150,19 @@ function getErrorSummary(error: unknown): string {
 
 function createSiblingStoragePath(storagePath: string, fileName: string): string {
   return path.join(path.dirname(storagePath), fileName);
+}
+
+const execFileAsync = promisify(execFile);
+
+async function loadTaskNotesFromCli(
+  taskId: ExportedTaskInput["localTaskId"]
+): Promise<Array<{ id: ExportedTaskInput["comments"][number]["localNoteId"]; tags: string[] }>> {
+  const { stdout } = await execFileAsync("todu", ["--format", "json", "note", "list", "--task", String(taskId)]);
+  const parsed = JSON.parse(stdout) as Array<{ id: string; tags?: unknown }>;
+  return parsed.map((note) => ({
+    id: note.id as ExportedTaskInput["comments"][number]["localNoteId"],
+    tags: Array.isArray(note.tags) ? note.tags.filter((tag): tag is string => typeof tag === "string") : [],
+  }));
 }
 
 export function createGitHubSyncProvider(
@@ -200,9 +221,7 @@ export function createGitHubSyncProvider(
     return settings;
   };
 
-  const validateBinding = (
-    binding: Parameters<SyncProvider["pull"]>[0]
-  ): GitHubRepositoryBinding => {
+  const validateBinding = (binding: IntegrationBinding): GitHubRepositoryBinding => {
     requireInitializedSettings();
     return parseGitHubBinding(binding);
   };
@@ -242,7 +261,7 @@ export function createGitHubSyncProvider(
       lastPullResult = null;
       lastPushResult = null;
     },
-    async pull(binding, _project): Promise<SyncProviderPullResult> {
+    async pull(binding, _project): Promise<SyncProviderPullResultV3> {
       const parsedBinding = validateBinding(binding);
       const logContext = createLogContext(binding, parsedBinding, "pull");
 
@@ -322,7 +341,7 @@ export function createGitHubSyncProvider(
         throw error;
       }
     },
-    async push(binding, tasks: TaskPushPayload[], _project): Promise<SyncProviderPushResult> {
+    async push(binding, tasks: ExportedTaskInput[], _project: Project): Promise<SyncProviderPushResult> {
       const parsedBinding = validateBinding(binding);
       const logContext = createLogContext(binding, parsedBinding, "push");
 
@@ -384,6 +403,7 @@ export function createGitHubSyncProvider(
           issueClient,
           itemLinkStore: linkStore,
           commentLinkStore,
+          loadTaskNotes: options.loadTaskNotes,
         });
 
         for (const createdComment of pushCommentsResult.createdComments) {
@@ -446,34 +466,6 @@ export function createGitHubSyncProvider(
         throw error;
       }
     },
-    mapToTask(external: ExternalTask, project: Project): Task {
-      return {
-        id: createImportedTaskId(external.externalId),
-        title: external.title,
-        status: normalizeTaskStatus(external.status),
-        priority: normalizeTaskPriority(external.priority),
-        projectId: project.id,
-        labels: [...(external.labels ?? [])],
-        assignees: [...(external.assignees ?? [])],
-        externalId: external.externalId,
-        sourceUrl: external.sourceUrl,
-        createdAt: external.createdAt ?? external.updatedAt ?? DEFAULT_TIMESTAMP,
-        updatedAt: external.updatedAt ?? external.createdAt ?? DEFAULT_TIMESTAMP,
-      };
-    },
-    mapFromTask(task: TaskPushPayload, _project: Project): ExternalTask {
-      return {
-        externalId: task.externalId ?? String(task.id),
-        title: task.title,
-        description: task.description,
-        status: task.status,
-        priority: task.priority,
-        labels: [...task.labels],
-        sourceUrl: task.sourceUrl,
-        createdAt: task.createdAt,
-        updatedAt: task.updatedAt,
-      };
-    },
     getState(): GitHubProviderState {
       return {
         initialized: settings !== null,
@@ -488,7 +480,7 @@ export function createGitHubSyncProvider(
   };
 }
 
-export const githubProvider = createGitHubSyncProvider();
+export const githubProvider = createGitHubSyncProvider({ loadTaskNotes: loadTaskNotesFromCli });
 
 export const syncProvider: SyncProviderRegistration = {
   manifest: {
@@ -498,23 +490,3 @@ export const syncProvider: SyncProviderRegistration = {
   },
   provider: githubProvider,
 };
-
-function normalizeTaskStatus(status: string | undefined): Task["status"] {
-  if (status && OPEN_TASK_STATUSES.has(status)) {
-    return status as Task["status"];
-  }
-
-  if (status === "done" || status === "canceled") {
-    return status;
-  }
-
-  return "active";
-}
-
-function normalizeTaskPriority(priority: string | undefined): Task["priority"] {
-  if (priority && TASK_PRIORITIES.has(priority)) {
-    return priority as Task["priority"];
-  }
-
-  return "medium";
-}

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -157,11 +157,20 @@ const execFileAsync = promisify(execFile);
 async function loadTaskNotesFromCli(
   taskId: ExportedTaskInput["localTaskId"]
 ): Promise<Array<{ id: ExportedTaskInput["comments"][number]["localNoteId"]; tags: string[] }>> {
-  const { stdout } = await execFileAsync("todu", ["--format", "json", "note", "list", "--task", String(taskId)]);
+  const { stdout } = await execFileAsync("todu", [
+    "--format",
+    "json",
+    "note",
+    "list",
+    "--task",
+    String(taskId),
+  ]);
   const parsed = JSON.parse(stdout) as Array<{ id: string; tags?: unknown }>;
   return parsed.map((note) => ({
     id: note.id as ExportedTaskInput["comments"][number]["localNoteId"],
-    tags: Array.isArray(note.tags) ? note.tags.filter((tag): tag is string => typeof tag === "string") : [],
+    tags: Array.isArray(note.tags)
+      ? note.tags.filter((tag): tag is string => typeof tag === "string")
+      : [],
   }));
 }
 
@@ -341,7 +350,11 @@ export function createGitHubSyncProvider(
         throw error;
       }
     },
-    async push(binding, tasks: ExportedTaskInput[], _project: Project): Promise<SyncProviderPushResult> {
+    async push(
+      binding,
+      tasks: ExportedTaskInput[],
+      _project: Project
+    ): Promise<SyncProviderPushResult> {
       const parsedBinding = validateBinding(binding);
       const logContext = createLogContext(binding, parsedBinding, "push");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ export {
   type GitHubComment,
   type GitHubIssue,
   type GitHubIssueClient,
+  type GitHubUserRef,
   type InMemoryGitHubIssueClient,
 } from "@/github-client";
 export { createHttpGitHubIssueClient } from "@/github-http-client";
@@ -52,7 +53,8 @@ export {
   createGitHubPriorityFromTask,
   createGitHubStatusFromTask,
   getNormalGitHubLabels,
-  mapGitHubIssueToExternalTask,
+  mapGitHubIssueToImportedTask,
+  mapGitHubUserToExternalActorRef,
   mergeGitHubLabels,
   normalizeGitHubIssuePriority,
   normalizeGitHubIssueStatus,


### PR DESCRIPTION
## Summary\n- finish the GitHub sync API v3 and stale comment-link repair work\n- add actor-rollout verification coverage for assignee and comment-author identity handling\n- document current bidirectional assignee sync behavior and rollout caveats\n\n## Verification\n- ./scripts/pre-pr.sh\n\n## Tasks\n- task-36a6acfb\n- task-4f7810f1\n- task-9ec1e148