### PR TITLE
Fix linked issue reconciliation during pull

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -1033,22 +1033,25 @@ describe("local provider state persistence", () => {
       comments: [],
     });
     expect(listCommentsCalls).toEqual([2]);
-    expect(secondProvider.getState().itemLinks).toEqual([
-      {
-        bindingId: createIntegrationBindingId("binding-1"),
-        taskId: createTaskId("github:evcraddock/todu-github-plugin#1"),
-        issueNumber: 1,
-        externalId: "evcraddock/todu-github-plugin#1",
-        lastMirroredAt: "2026-03-10T00:00:00.000Z",
-      },
-      {
-        bindingId: createIntegrationBindingId("binding-1"),
-        taskId: createTaskId("github:evcraddock/todu-github-plugin#2"),
-        issueNumber: 2,
-        externalId: "evcraddock/todu-github-plugin#2",
-        lastMirroredAt: expect.any(String),
-      },
-    ]);
+    expect(secondProvider.getState().itemLinks).toHaveLength(2);
+    expect(secondProvider.getState().itemLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          bindingId: createIntegrationBindingId("binding-1"),
+          taskId: createTaskId("github:evcraddock/todu-github-plugin#1"),
+          issueNumber: 1,
+          externalId: "evcraddock/todu-github-plugin#1",
+          lastMirroredAt: "2026-03-10T00:00:00.000Z",
+        }),
+        expect.objectContaining({
+          bindingId: createIntegrationBindingId("binding-1"),
+          taskId: createTaskId("github:evcraddock/todu-github-plugin#2"),
+          issueNumber: 2,
+          externalId: "evcraddock/todu-github-plugin#2",
+          lastMirroredAt: expect.any(String),
+        }),
+      ])
+    );
     expect(secondProvider.getState().commentLinks).toEqual([
       {
         bindingId: createIntegrationBindingId("binding-1"),
@@ -2849,6 +2852,121 @@ describe("incremental sync", () => {
       expect(linkStore.getByIssueNumber(binding.id, 1)?.lastMirroredAt).toBe(
         "2026-03-10T00:02:00.000Z"
       );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("reconciles linked issues when the pull cursor skipped a remote update", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-10T00:01:00.000Z"));
+
+      const issueClient = createInMemoryGitHubIssueClient();
+      issueClient.seedIssues(repositoryTarget(), [
+        createIssue({
+          number: 1,
+          title: "Remote close can be missed",
+          state: "open",
+          labels: ["status:active"],
+          updatedAt: "2026-03-10T00:00:00.000Z",
+        }),
+      ]);
+
+      const binding = createBinding();
+      const linkStore = createInMemoryGitHubItemLinkStore();
+      const runtimeStore = createInMemoryBindingRuntimeStore();
+      const provider = createGitHubSyncProvider({ issueClient, linkStore, runtimeStore });
+      await provider.initialize({ settings: { token: "secret-token" } });
+
+      const firstPull = await provider.pull(binding, createProject());
+      expect(firstPull.tasks).toHaveLength(1);
+
+      issueClient.seedIssues(repositoryTarget(), [
+        createIssue({
+          number: 1,
+          title: "Remote close can be missed",
+          state: "closed",
+          labels: ["status:done"],
+          updatedAt: "2026-03-10T00:02:00.000Z",
+        }),
+      ]);
+
+      const previousState = runtimeStore.get(binding.id);
+      expect(previousState).not.toBeNull();
+      runtimeStore.save({
+        ...previousState!,
+        cursor: "2026-03-10T00:03:00.000Z",
+      });
+
+      vi.setSystemTime(new Date("2026-03-10T00:04:00.000Z"));
+      const secondPull = await provider.pull(binding, createProject());
+
+      expect(secondPull.tasks).toEqual([
+        expect.objectContaining({
+          externalId: "evcraddock/todu-github-plugin#1",
+          status: "done",
+          updatedAt: "2026-03-10T00:02:00.000Z",
+        }),
+      ]);
+      expect(linkStore.getByIssueNumber(binding.id, 1)).toMatchObject({
+        lastMirroredAt: "2026-03-10T00:02:00.000Z",
+        lastReconciledAt: "2026-03-10T00:04:00.000Z",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("throttles unchanged linked issue checks and periodically re-delivers checked state", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date("2026-03-10T00:01:00.000Z"));
+
+      const issueClient = createInMemoryGitHubIssueClient();
+      issueClient.seedIssues(repositoryTarget(), [
+        createIssue({
+          number: 1,
+          title: "Stable linked issue",
+          state: "open",
+          labels: ["status:active"],
+          updatedAt: "2026-03-10T00:00:00.000Z",
+        }),
+      ]);
+
+      const binding = createBinding();
+      const linkStore = createInMemoryGitHubItemLinkStore();
+      const provider = createGitHubSyncProvider({ issueClient, linkStore });
+      await provider.initialize({ settings: { token: "secret-token" } });
+
+      await provider.pull(binding, createProject());
+
+      let getIssueCalls = 0;
+      const originalGetIssue = issueClient.getIssue.bind(issueClient);
+      issueClient.getIssue = async (target, issueNumber) => {
+        getIssueCalls += 1;
+        return originalGetIssue(target, issueNumber);
+      };
+
+      vi.setSystemTime(new Date("2026-03-10T00:02:00.000Z"));
+      const secondPull = await provider.pull(binding, createProject());
+      expect(secondPull.tasks).toHaveLength(0);
+      expect(getIssueCalls).toBe(1);
+
+      vi.setSystemTime(new Date("2026-03-10T00:03:00.000Z"));
+      const thirdPull = await provider.pull(binding, createProject());
+      expect(thirdPull.tasks).toHaveLength(0);
+      expect(getIssueCalls).toBe(1);
+
+      vi.setSystemTime(new Date("2026-03-10T01:02:00.000Z"));
+      const fourthPull = await provider.pull(binding, createProject());
+      expect(fourthPull.tasks).toEqual([
+        expect.objectContaining({
+          externalId: "evcraddock/todu-github-plugin#1",
+          status: "active",
+        }),
+      ]);
+      expect(getIssueCalls).toBe(2);
     } finally {
       vi.useRealTimers();
     }

--- a/src/github-bootstrap.ts
+++ b/src/github-bootstrap.ts
@@ -20,6 +20,8 @@ const TASK_BOOTSTRAP_EXPORT_STATUSES = new Set<ExportedTaskInput["status"]>([
   "waiting",
 ]);
 
+const DEFAULT_LINKED_ISSUE_RECONCILE_INTERVAL_MS = 60 * 60 * 1000;
+
 export interface GitHubBootstrapImportResult {
   tasks: ImportedTaskInput[];
   createdLinks: GitHubItemLink[];
@@ -50,6 +52,8 @@ export async function bootstrapGitHubIssuesToTasks(input: {
   linkStore: GitHubItemLinkStore;
   since?: string;
   importClosedOnBootstrap?: boolean;
+  reconcileCheckedAt?: string;
+  reconcileIntervalMs?: number;
 }): Promise<GitHubBootstrapImportResult> {
   const issues = await input.issueClient.listIssues(
     { owner: input.owner, repo: input.repo },
@@ -60,11 +64,14 @@ export async function bootstrapGitHubIssuesToTasks(input: {
   const createdLinks: GitHubItemLink[] = [];
   const touchedIssueNumbers: number[] = [];
 
+  const listedIssueNumbers = new Set<number>();
+
   for (const issue of issues) {
     if (issue.isPullRequest) {
       continue;
     }
 
+    listedIssueNumbers.add(issue.number);
     const existingLink = input.linkStore.getByIssueNumber(input.binding.id, issue.number);
     if (!existingLink && issue.state !== "open" && !input.importClosedOnBootstrap) {
       continue;
@@ -87,11 +94,130 @@ export async function bootstrapGitHubIssuesToTasks(input: {
     touchedIssueNumbers.push(issue.number);
   }
 
+  if (input.since) {
+    await reconcileLinkedIssues({
+      binding: input.binding,
+      owner: input.owner,
+      repo: input.repo,
+      issueClient: input.issueClient,
+      linkStore: input.linkStore,
+      listedIssueNumbers,
+      since: input.since,
+      checkedAt: input.reconcileCheckedAt ?? new Date().toISOString(),
+      reconcileIntervalMs: input.reconcileIntervalMs ?? DEFAULT_LINKED_ISSUE_RECONCILE_INTERVAL_MS,
+      tasks,
+      touchedIssueNumbers,
+    });
+  }
+
   return {
     tasks,
     createdLinks,
     touchedIssueNumbers,
   };
+}
+
+async function reconcileLinkedIssues(input: {
+  binding: IntegrationBinding;
+  owner: string;
+  repo: string;
+  issueClient: GitHubIssueClient;
+  linkStore: GitHubItemLinkStore;
+  listedIssueNumbers: Set<number>;
+  since: string;
+  checkedAt: string;
+  reconcileIntervalMs: number;
+  tasks: ImportedTaskInput[];
+  touchedIssueNumbers: number[];
+}): Promise<void> {
+  for (const link of input.linkStore.list(input.binding.id)) {
+    if (input.listedIssueNumbers.has(link.issueNumber)) {
+      continue;
+    }
+
+    if (
+      !shouldReconcileLinkedIssue(link, input.since, input.checkedAt, input.reconcileIntervalMs)
+    ) {
+      continue;
+    }
+
+    const issue = await input.issueClient.getIssue(
+      { owner: input.owner, repo: input.repo },
+      link.issueNumber
+    );
+
+    if (!issue || issue.isPullRequest) {
+      input.linkStore.save({ ...link, lastReconciledAt: input.checkedAt });
+      continue;
+    }
+
+    const issueLastMirroredAt = issue.updatedAt ?? issue.createdAt;
+    const remoteIssueIsNewer =
+      issueLastMirroredAt != null && isRemoteIssueNewer(issueLastMirroredAt, link.lastMirroredAt);
+    const updatedLink: GitHubItemLink = {
+      ...link,
+      lastReconciledAt: input.checkedAt,
+      ...(issueLastMirroredAt && remoteIssueIsNewer ? { lastMirroredAt: issueLastMirroredAt } : {}),
+    };
+    input.linkStore.save(updatedLink);
+
+    // First reconciliation pass records that the issue was checked. Later passes
+    // periodically re-deliver linked issue state even when the remote timestamp did
+    // not change, so a host-side import failure cannot permanently strand local state.
+    if (!remoteIssueIsNewer && !link.lastReconciledAt) {
+      continue;
+    }
+
+    input.tasks.push(mapGitHubIssueToImportedTask(issue));
+    input.touchedIssueNumbers.push(issue.number);
+  }
+}
+
+function shouldReconcileLinkedIssue(
+  link: GitHubItemLink,
+  since: string,
+  checkedAt: string,
+  reconcileIntervalMs: number
+): boolean {
+  if (!link.lastMirroredAt) {
+    return true;
+  }
+
+  const sinceTime = Date.parse(since);
+  const lastMirroredTime = Date.parse(link.lastMirroredAt);
+  if (Number.isNaN(sinceTime) || Number.isNaN(lastMirroredTime)) {
+    return true;
+  }
+
+  if (lastMirroredTime >= sinceTime) {
+    return false;
+  }
+
+  if (!link.lastReconciledAt) {
+    return true;
+  }
+
+  const checkedTime = Date.parse(checkedAt);
+  const lastReconciledTime = Date.parse(link.lastReconciledAt);
+  if (Number.isNaN(checkedTime) || Number.isNaN(lastReconciledTime)) {
+    return true;
+  }
+
+  return checkedTime - lastReconciledTime >= reconcileIntervalMs;
+}
+
+function isRemoteIssueNewer(remoteUpdatedAt: string, lastMirroredAt: string | undefined): boolean {
+  if (!lastMirroredAt) {
+    return true;
+  }
+
+  const remoteTime = Date.parse(remoteUpdatedAt);
+  const lastMirroredTime = Date.parse(lastMirroredAt);
+  if (Number.isNaN(remoteTime) || Number.isNaN(lastMirroredTime)) {
+    return remoteUpdatedAt !== lastMirroredAt;
+  }
+
+  return remoteTime > lastMirroredTime;
 }
 
 export async function bootstrapTasksToGitHubIssues(input: {

--- a/src/github-links.ts
+++ b/src/github-links.ts
@@ -12,6 +12,7 @@ export interface GitHubItemLink {
   issueNumber: number;
   externalId: string;
   lastMirroredAt?: string;
+  lastReconciledAt?: string;
 }
 
 export interface GitHubItemLinkStore {

--- a/src/github-provider.ts
+++ b/src/github-provider.ts
@@ -305,6 +305,7 @@ export function createGitHubSyncProvider(
           linkStore,
           since: pullSince,
           importClosedOnBootstrap: pullSince == null && isImportClosedOnBootstrapEnabled(binding),
+          reconcileCheckedAt: pullStartedAt.toISOString(),
         });
 
         const pullCommentsResult = await pullComments({


### PR DESCRIPTION
## Summary
- reconcile already-linked GitHub issues during incremental pulls
- periodically re-deliver linked issue state so missed/import-failed remote updates can recover
- add regression coverage for skipped remote close updates

## Verification
- ./scripts/pre-pr.sh
- npm run build

Task: #450