### PR TITLE
fix: lazily load comment note tags

### DIFF
--- a/src/__tests__/github-provider.test.ts
+++ b/src/__tests__/github-provider.test.ts
@@ -1202,6 +1202,198 @@ describe("comment sync", () => {
     expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
   });
 
+  it("does not load task notes when linked tasks have no comments", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue without comments",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+
+    const binding = createBinding();
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    linkStore.save(
+      createLinkFromTask(
+        binding,
+        createTaskId("task-1"),
+        "evcraddock",
+        "todu-github-plugin",
+        1,
+        "2026-03-10T02:00:00.000Z"
+      )
+    );
+
+    let loadTaskNotesCalls = 0;
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore,
+      loadTaskNotes: async () => {
+        loadTaskNotesCalls += 1;
+        return [];
+      },
+    });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue without comments",
+          status: "active",
+          comments: [],
+          updatedAt: "2026-03-10T01:00:00.000Z",
+        }),
+      ],
+      createProject()
+    );
+
+    expect(loadTaskNotesCalls).toBe(0);
+  });
+
+  it("does not load task notes when all comments already have links", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with linked comment",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Already mirrored",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const binding = createBinding();
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+    commentLinkStore.save({
+      bindingId: binding.id,
+      taskId: createTaskId("task-1"),
+      noteId: createNoteId("note-1"),
+      issueNumber: 1,
+      githubCommentId: 100,
+      lastMirroredAt: "2026-03-10T00:00:00.000Z",
+    });
+
+    let loadTaskNotesCalls = 0;
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+      loadTaskNotes: async () => {
+        loadTaskNotesCalls += 1;
+        return [];
+      },
+    });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with linked comment",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Already mirrored",
+              author: "octocat",
+              createdAt: "2026-03-10T00:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(loadTaskNotesCalls).toBe(0);
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+  });
+
+  it("loads task notes for commented tasks so sync tags prevent imported comment echoes", async () => {
+    const issueClient = createInMemoryGitHubIssueClient();
+    issueClient.seedIssues(repositoryTarget(), [
+      createIssue({
+        number: 1,
+        title: "Issue with imported comment tags",
+        state: "open",
+        labels: ["status:active", "priority:medium"],
+      }),
+    ]);
+    issueClient.seedComments(repositoryTarget(), 1, [
+      createGitHubComment({
+        id: 100,
+        issueNumber: 1,
+        body: "Imported from GitHub",
+        author: "octocat",
+        createdAt: "2026-03-10T00:00:00.000Z",
+      }),
+    ]);
+
+    const binding = createBinding();
+    const linkStore = createInMemoryGitHubItemLinkStore();
+    const commentLinkStore = createInMemoryGitHubCommentLinkStore();
+    linkStore.save(
+      createLinkFromTask(binding, createTaskId("task-1"), "evcraddock", "todu-github-plugin", 1)
+    );
+
+    let loadTaskNotesCalls = 0;
+    const provider = createGitHubSyncProvider({
+      issueClient,
+      linkStore,
+      commentLinkStore,
+      loadTaskNotes: async () => {
+        loadTaskNotesCalls += 1;
+        return [{ id: "note-1", tags: ["sync:externalId:100"] }];
+      },
+    });
+    await provider.initialize({ settings: { token: "secret-token" } });
+
+    const result = await provider.push(
+      binding,
+      [
+        createTaskWithDetail({
+          id: "task-1",
+          title: "Issue with imported comment tags",
+          status: "active",
+          comments: [
+            createNote({
+              id: "note-1",
+              content: "Imported from GitHub",
+              author: "octocat",
+              createdAt: "2026-03-10T00:00:00.000Z",
+            }),
+          ],
+        }),
+      ],
+      createProject()
+    );
+
+    expect(loadTaskNotesCalls).toBe(1);
+    expect(result.commentLinks).toEqual([
+      expect.objectContaining({
+        localNoteId: createNoteId("note-1"),
+        externalCommentId: "100",
+      }),
+    ]);
+    expect(issueClient.snapshotComments(repositoryTarget(), 1)).toHaveLength(1);
+  });
+
   it("repairs stale local comment links by trusting the note sync tag", async () => {
     const issueClient = createInMemoryGitHubIssueClient();
     issueClient.seedIssues(repositoryTarget(), [

--- a/src/github-comments.ts
+++ b/src/github-comments.ts
@@ -256,14 +256,23 @@ export async function pushComments(input: {
     }
 
     const externalTaskId = String(task.localTaskId);
-    const taskNotes = input.loadTaskNotes ? await input.loadTaskNotes(task.localTaskId) : [];
-    const noteTagsById = new Map(taskNotes.map((note) => [String(note.id), note.tags]));
     const currentNoteIds = new Set(task.comments.map((comment) => String(comment.localNoteId)));
-
-    for (const existingCommentLink of input.commentLinkStore.listByIssue(
+    const existingCommentLinks = input.commentLinkStore.listByIssue(
       input.binding.id,
       itemLink.issueNumber
-    )) {
+    );
+    let noteTagsById: Map<string, string[]> | null = null;
+    const loadNoteTagsForTask = async (): Promise<Map<string, string[]>> => {
+      if (noteTagsById) {
+        return noteTagsById;
+      }
+
+      const taskNotes = input.loadTaskNotes ? await input.loadTaskNotes(task.localTaskId) : [];
+      noteTagsById = new Map(taskNotes.map((note) => [String(note.id), note.tags]));
+      return noteTagsById;
+    };
+
+    for (const existingCommentLink of existingCommentLinks) {
       if (currentNoteIds.has(String(existingCommentLink.noteId))) {
         continue;
       }
@@ -273,9 +282,18 @@ export async function pushComments(input: {
     }
 
     for (const comment of task.comments) {
+      const commentTags = (comment as { tags?: unknown }).tags;
+      const shouldLoadTags = shouldLoadNoteTagsForComment({
+        comment,
+        commentTags,
+        existingCommentLinks,
+      });
+      const loadedTags = shouldLoadTags
+        ? (await loadNoteTagsForTask()).get(String(comment.localNoteId))
+        : undefined;
       const commentWithTags = {
         ...comment,
-        tags: noteTagsById.get(String(comment.localNoteId)) ?? (comment as { tags?: unknown }).tags,
+        tags: loadedTags ?? commentTags,
       };
       const existingLink = resolveCommentLinkForPush({
         binding: input.binding,
@@ -323,6 +341,28 @@ export async function pushComments(input: {
   }
 
   return { commentLinks, createdComments, updatedComments };
+}
+
+function shouldLoadNoteTagsForComment(input: {
+  comment: ExportedCommentInput;
+  commentTags: unknown;
+  existingCommentLinks: GitHubCommentLink[];
+}): boolean {
+  if (getSyncExternalCommentIdFromTags(input.commentTags) !== null) {
+    return false;
+  }
+
+  const existingLink = input.existingCommentLinks.find(
+    (link) => link.noteId === input.comment.localNoteId
+  );
+  if (!existingLink) {
+    return true;
+  }
+
+  return input.existingCommentLinks.some(
+    (link) =>
+      link.noteId !== input.comment.localNoteId && String(link.noteId).startsWith("external:")
+  );
 }
 
 async function updateGitHubCommentIfNeeded(


### PR DESCRIPTION
## Summary

Mitigates GitHub comment push CPU/log pressure by lazily loading note tags only when legacy tag-based comment provenance can affect the push decision.

## Task

- task-6fa5fce9

## Changes

- Avoids `loadTaskNotes` for linked tasks with no local comments.
- Avoids `loadTaskNotes` when comments already have usable plugin comment-link records.
- Still loads note tags for legacy imported-comment loop prevention and stale comment-link repair cases.
- Adds regression coverage for no-comment tasks, already-linked comments, and legacy sync-tag handling.

## Testing

- [x] Unit tests added/updated
- [ ] Manual testing performed
- [x] `./scripts/pre-pr.sh`
- [x] `npm run build`

## Checklist

- [x] `./scripts/pre-pr.sh` passes
- [ ] Documentation updated (if needed)
- [x] No unrelated changes included

Notes: this is an interim mitigation. The full architecture fix is task-ef90d902 in Todu core: replace tag-based comment sync provenance with first-class structured sync links.
